### PR TITLE
[Feat] 기기별 오토레이아웃 대응

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,9 +86,9 @@ fastlane/test_output
 iOSInjectionProject/
 
 ### SwiftPackageManager ###
-Packages
-xcuserdata
-*.xcodeproj
+# Packages
+# xcuserdata
+# *.xcodeproj
 
 
 ### SwiftPM ###

--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		A791212B2950D5A20044E652 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791212A2950D5A20044E652 /* UIView+.swift */; };
 		A791212D2950D5B00044E652 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791212C2950D5B00044E652 /* UIStackView+.swift */; };
 		A79121482952259A0044E652 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A79121472952259A0044E652 /* DeviceKit */; };
+		A791214B295227230044E652 /* DeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791214A295227230044E652 /* DeviceManager.swift */; };
+		A791214D295228200044E652 /* CGFloat+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791214C295228200044E652 /* CGFloat+.swift */; };
+		A791214F295228530044E652 /* Double+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791214E295228530044E652 /* Double+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +72,9 @@
 		A79121282950D2000044E652 /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		A791212A2950D5A20044E652 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		A791212C2950D5B00044E652 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+		A791214A295227230044E652 /* DeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceManager.swift; sourceTree = "<group>"; };
+		A791214C295228200044E652 /* CGFloat+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+.swift"; sourceTree = "<group>"; };
+		A791214E295228530044E652 /* Double+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +127,7 @@
 		A79120D0294A0A5F0044E652 /* HRHN */ = {
 			isa = PBXGroup;
 			children = (
+				A7912149295227140044E652 /* Managers */,
 				A791210F294B1A3A0044E652 /* Extension */,
 				A7912111294B1A590044E652 /* Model */,
 				A791210E294B1A2A0044E652 /* ViewModel */,
@@ -173,6 +180,8 @@
 			children = (
 				A791212A2950D5A20044E652 /* UIView+.swift */,
 				A791212C2950D5B00044E652 /* UIStackView+.swift */,
+				A791214C295228200044E652 /* CGFloat+.swift */,
+				A791214E295228530044E652 /* Double+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -220,6 +229,14 @@
 				A7912124294C40900044E652 /* SampleUI.swift */,
 			);
 			path = UI;
+			sourceTree = "<group>";
+		};
+		A7912149295227140044E652 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				A791214A295227230044E652 /* DeviceManager.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -360,6 +377,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A791214D295228200044E652 /* CGFloat+.swift in Sources */,
 				A791210C294B190E0044E652 /* TodayViewController.swift in Sources */,
 				A7912117294B1AB40044E652 /* SampleRepository.swift in Sources */,
 				A79121272950D12A0044E652 /* TabBarController.swift in Sources */,
@@ -367,11 +385,13 @@
 				A791211F294B1B0A0044E652 /* SampleViewModel.swift in Sources */,
 				A7912115294B1AAB0044E652 /* SampleModel.swift in Sources */,
 				A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */,
+				A791214B295227230044E652 /* DeviceManager.swift in Sources */,
 				A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */,
 				A7912125294C40900044E652 /* SampleUI.swift in Sources */,
 				A791212B2950D5A20044E652 /* UIView+.swift in Sources */,
 				A791212D2950D5B00044E652 /* UIStackView+.swift in Sources */,
 				A7912121294B1B440044E652 /* CoreDataManager.swift in Sources */,
+				A791214F295228530044E652 /* Double+.swift in Sources */,
 				A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -1,0 +1,756 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D1294A0A5F0044E652 /* AppDelegate.swift */; };
+		A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D3294A0A5F0044E652 /* SceneDelegate.swift */; };
+		A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
+		A79120DE294A0A610044E652 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A79120DD294A0A610044E652 /* Assets.xcassets */; };
+		A79120E1294A0A610044E652 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A79120DF294A0A610044E652 /* LaunchScreen.storyboard */; };
+		A79120EC294A0A610044E652 /* HRHNTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120EB294A0A610044E652 /* HRHNTests.swift */; };
+		A79120F6294A0A610044E652 /* HRHNUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120F5294A0A610044E652 /* HRHNUITests.swift */; };
+		A79120F8294A0A610044E652 /* HRHNUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120F7294A0A610044E652 /* HRHNUITestsLaunchTests.swift */; };
+		A7912106294B0C3F0044E652 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = A7912105294B0C3F0044E652 /* SnapKit */; };
+		A791210C294B190E0044E652 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791210B294B190E0044E652 /* TodayViewController.swift */; };
+		A7912115294B1AAB0044E652 /* SampleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912114294B1AAB0044E652 /* SampleModel.swift */; };
+		A7912117294B1AB40044E652 /* SampleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912116294B1AB40044E652 /* SampleRepository.swift */; };
+		A791211F294B1B0A0044E652 /* SampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791211E294B1B0A0044E652 /* SampleViewModel.swift */; };
+		A7912121294B1B440044E652 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912120294B1B440044E652 /* CoreDataManager.swift */; };
+		A7912125294C40900044E652 /* SampleUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912124294C40900044E652 /* SampleUI.swift */; };
+		A79121272950D12A0044E652 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121262950D12A0044E652 /* TabBarController.swift */; };
+		A79121292950D2000044E652 /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121282950D2000044E652 /* RecordViewController.swift */; };
+		A791212B2950D5A20044E652 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791212A2950D5A20044E652 /* UIView+.swift */; };
+		A791212D2950D5B00044E652 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A791212C2950D5B00044E652 /* UIStackView+.swift */; };
+		A79121482952259A0044E652 /* DeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = A79121472952259A0044E652 /* DeviceKit */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A79120E8294A0A610044E652 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79120C6294A0A5F0044E652 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A79120CD294A0A5F0044E652;
+			remoteInfo = HRHN;
+		};
+		A79120F2294A0A610044E652 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79120C6294A0A5F0044E652 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A79120CD294A0A5F0044E652;
+			remoteInfo = HRHN;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A79120CE294A0A5F0044E652 /* HRHN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HRHN.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A79120D1294A0A5F0044E652 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A79120D3294A0A5F0044E652 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		A79120DB294A0A5F0044E652 /* HRHN.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = HRHN.xcdatamodel; sourceTree = "<group>"; };
+		A79120DD294A0A610044E652 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A79120E0294A0A610044E652 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		A79120E2294A0A610044E652 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A79120E7294A0A610044E652 /* HRHNTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HRHNTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A79120EB294A0A610044E652 /* HRHNTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HRHNTests.swift; sourceTree = "<group>"; };
+		A79120F1294A0A610044E652 /* HRHNUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HRHNUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A79120F5294A0A610044E652 /* HRHNUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HRHNUITests.swift; sourceTree = "<group>"; };
+		A79120F7294A0A610044E652 /* HRHNUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HRHNUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		A791210B294B190E0044E652 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
+		A7912114294B1AAB0044E652 /* SampleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleModel.swift; sourceTree = "<group>"; };
+		A7912116294B1AB40044E652 /* SampleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRepository.swift; sourceTree = "<group>"; };
+		A791211E294B1B0A0044E652 /* SampleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleViewModel.swift; sourceTree = "<group>"; };
+		A7912120294B1B440044E652 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
+		A7912124294C40900044E652 /* SampleUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleUI.swift; sourceTree = "<group>"; };
+		A79121262950D12A0044E652 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		A79121282950D2000044E652 /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
+		A791212A2950D5A20044E652 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		A791212C2950D5B00044E652 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A79120CB294A0A5F0044E652 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A7912106294B0C3F0044E652 /* SnapKit in Frameworks */,
+				A79121482952259A0044E652 /* DeviceKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A79120E4294A0A610044E652 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A79120EE294A0A610044E652 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A79120C5294A0A5F0044E652 = {
+			isa = PBXGroup;
+			children = (
+				A79120D0294A0A5F0044E652 /* HRHN */,
+				A79120EA294A0A610044E652 /* HRHNTests */,
+				A79120F4294A0A610044E652 /* HRHNUITests */,
+				A79120CF294A0A5F0044E652 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A79120CF294A0A5F0044E652 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A79120CE294A0A5F0044E652 /* HRHN.app */,
+				A79120E7294A0A610044E652 /* HRHNTests.xctest */,
+				A79120F1294A0A610044E652 /* HRHNUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A79120D0294A0A5F0044E652 /* HRHN */ = {
+			isa = PBXGroup;
+			children = (
+				A791210F294B1A3A0044E652 /* Extension */,
+				A7912111294B1A590044E652 /* Model */,
+				A791210E294B1A2A0044E652 /* ViewModel */,
+				A791210D294B1A230044E652 /* View */,
+				A79120D1294A0A5F0044E652 /* AppDelegate.swift */,
+				A79120D3294A0A5F0044E652 /* SceneDelegate.swift */,
+				A79120DD294A0A610044E652 /* Assets.xcassets */,
+				A79120DF294A0A610044E652 /* LaunchScreen.storyboard */,
+				A79120E2294A0A610044E652 /* Info.plist */,
+			);
+			path = HRHN;
+			sourceTree = "<group>";
+		};
+		A79120EA294A0A610044E652 /* HRHNTests */ = {
+			isa = PBXGroup;
+			children = (
+				A79120EB294A0A610044E652 /* HRHNTests.swift */,
+			);
+			path = HRHNTests;
+			sourceTree = "<group>";
+		};
+		A79120F4294A0A610044E652 /* HRHNUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A79120F5294A0A610044E652 /* HRHNUITests.swift */,
+				A79120F7294A0A610044E652 /* HRHNUITestsLaunchTests.swift */,
+			);
+			path = HRHNUITests;
+			sourceTree = "<group>";
+		};
+		A791210D294B1A230044E652 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A7912123294C40160044E652 /* UI */,
+				A7912122294C40100044E652 /* VC */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		A791210E294B1A2A0044E652 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				A791211E294B1B0A0044E652 /* SampleViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		A791210F294B1A3A0044E652 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				A791212A2950D5A20044E652 /* UIView+.swift */,
+				A791212C2950D5B00044E652 /* UIStackView+.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		A7912111294B1A590044E652 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				A7912112294B1A670044E652 /* CoreData */,
+				A7912113294B1A700044E652 /* Repository */,
+				A7912114294B1AAB0044E652 /* SampleModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		A7912112294B1A670044E652 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */,
+				A7912120294B1B440044E652 /* CoreDataManager.swift */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
+		A7912113294B1A700044E652 /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				A7912116294B1AB40044E652 /* SampleRepository.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		A7912122294C40100044E652 /* VC */ = {
+			isa = PBXGroup;
+			children = (
+				A79121262950D12A0044E652 /* TabBarController.swift */,
+				A791210B294B190E0044E652 /* TodayViewController.swift */,
+				A79121282950D2000044E652 /* RecordViewController.swift */,
+			);
+			path = VC;
+			sourceTree = "<group>";
+		};
+		A7912123294C40160044E652 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				A7912124294C40900044E652 /* SampleUI.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A79120CD294A0A5F0044E652 /* HRHN */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A79120FB294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHN" */;
+			buildPhases = (
+				A79120CA294A0A5F0044E652 /* Sources */,
+				A79120CB294A0A5F0044E652 /* Frameworks */,
+				A79120CC294A0A5F0044E652 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HRHN;
+			packageProductDependencies = (
+				A7912105294B0C3F0044E652 /* SnapKit */,
+				A79121472952259A0044E652 /* DeviceKit */,
+			);
+			productName = HRHN;
+			productReference = A79120CE294A0A5F0044E652 /* HRHN.app */;
+			productType = "com.apple.product-type.application";
+		};
+		A79120E6294A0A610044E652 /* HRHNTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A79120FE294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHNTests" */;
+			buildPhases = (
+				A79120E3294A0A610044E652 /* Sources */,
+				A79120E4294A0A610044E652 /* Frameworks */,
+				A79120E5294A0A610044E652 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A79120E9294A0A610044E652 /* PBXTargetDependency */,
+			);
+			name = HRHNTests;
+			productName = HRHNTests;
+			productReference = A79120E7294A0A610044E652 /* HRHNTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A79120F0294A0A610044E652 /* HRHNUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A7912101294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHNUITests" */;
+			buildPhases = (
+				A79120ED294A0A610044E652 /* Sources */,
+				A79120EE294A0A610044E652 /* Frameworks */,
+				A79120EF294A0A610044E652 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A79120F3294A0A610044E652 /* PBXTargetDependency */,
+			);
+			name = HRHNUITests;
+			productName = HRHNUITests;
+			productReference = A79120F1294A0A610044E652 /* HRHNUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A79120C6294A0A5F0044E652 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1400;
+				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					A79120CD294A0A5F0044E652 = {
+						CreatedOnToolsVersion = 14.0;
+					};
+					A79120E6294A0A610044E652 = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = A79120CD294A0A5F0044E652;
+					};
+					A79120F0294A0A610044E652 = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = A79120CD294A0A5F0044E652;
+					};
+				};
+			};
+			buildConfigurationList = A79120C9294A0A5F0044E652 /* Build configuration list for PBXProject "HRHN" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A79120C5294A0A5F0044E652;
+			packageReferences = (
+				A7912104294B0C3F0044E652 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				A79121462952259A0044E652 /* XCRemoteSwiftPackageReference "DeviceKit" */,
+			);
+			productRefGroup = A79120CF294A0A5F0044E652 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A79120CD294A0A5F0044E652 /* HRHN */,
+				A79120E6294A0A610044E652 /* HRHNTests */,
+				A79120F0294A0A610044E652 /* HRHNUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A79120CC294A0A5F0044E652 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A79120E1294A0A610044E652 /* LaunchScreen.storyboard in Resources */,
+				A79120DE294A0A610044E652 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A79120E5294A0A610044E652 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A79120EF294A0A610044E652 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A79120CA294A0A5F0044E652 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A791210C294B190E0044E652 /* TodayViewController.swift in Sources */,
+				A7912117294B1AB40044E652 /* SampleRepository.swift in Sources */,
+				A79121272950D12A0044E652 /* TabBarController.swift in Sources */,
+				A79121292950D2000044E652 /* RecordViewController.swift in Sources */,
+				A791211F294B1B0A0044E652 /* SampleViewModel.swift in Sources */,
+				A7912115294B1AAB0044E652 /* SampleModel.swift in Sources */,
+				A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */,
+				A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */,
+				A7912125294C40900044E652 /* SampleUI.swift in Sources */,
+				A791212B2950D5A20044E652 /* UIView+.swift in Sources */,
+				A791212D2950D5B00044E652 /* UIStackView+.swift in Sources */,
+				A7912121294B1B440044E652 /* CoreDataManager.swift in Sources */,
+				A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A79120E3294A0A610044E652 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A79120EC294A0A610044E652 /* HRHNTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A79120ED294A0A610044E652 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A79120F8294A0A610044E652 /* HRHNUITestsLaunchTests.swift in Sources */,
+				A79120F6294A0A610044E652 /* HRHNUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A79120E9294A0A610044E652 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A79120CD294A0A5F0044E652 /* HRHN */;
+			targetProxy = A79120E8294A0A610044E652 /* PBXContainerItemProxy */;
+		};
+		A79120F3294A0A610044E652 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A79120CD294A0A5F0044E652 /* HRHN */;
+			targetProxy = A79120F2294A0A610044E652 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		A79120DF294A0A610044E652 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A79120E0294A0A610044E652 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		A79120F9294A0A610044E652 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A79120FA294A0A610044E652 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A79120FC294A0A610044E652 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = HRHN/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = "";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHN;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A79120FD294A0A610044E652 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = HRHN/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = "";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHN;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		A79120FF294A0A610044E652 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHNTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HRHN.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/HRHN";
+			};
+			name = Debug;
+		};
+		A7912100294A0A610044E652 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHNTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HRHN.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/HRHN";
+			};
+			name = Release;
+		};
+		A7912102294A0A610044E652 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHNUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = HRHN;
+			};
+			name = Debug;
+		};
+		A7912103294A0A610044E652 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHNUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = HRHN;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A79120C9294A0A5F0044E652 /* Build configuration list for PBXProject "HRHN" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A79120F9294A0A610044E652 /* Debug */,
+				A79120FA294A0A610044E652 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A79120FB294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHN" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A79120FC294A0A610044E652 /* Debug */,
+				A79120FD294A0A610044E652 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A79120FE294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHNTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A79120FF294A0A610044E652 /* Debug */,
+				A7912100294A0A610044E652 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A7912101294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHNUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A7912102294A0A610044E652 /* Debug */,
+				A7912103294A0A610044E652 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A7912104294B0C3F0044E652 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+		A79121462952259A0044E652 /* XCRemoteSwiftPackageReference "DeviceKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/devicekit/DeviceKit";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A7912105294B0C3F0044E652 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A7912104294B0C3F0044E652 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		A79121472952259A0044E652 /* DeviceKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A79121462952259A0044E652 /* XCRemoteSwiftPackageReference "DeviceKit" */;
+			productName = DeviceKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				A79120DB294A0A5F0044E652 /* HRHN.xcdatamodel */,
+			);
+			currentVersion = A79120DB294A0A5F0044E652 /* HRHN.xcdatamodel */;
+			path = HRHN.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = A79120C6294A0A5F0044E652 /* Project object */;
+}

--- a/HRHN.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/HRHN.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/HRHN.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/HRHN.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/HRHN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HRHN.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "devicekit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/devicekit/DeviceKit",
+      "state" : {
+        "revision" : "691fe8112cca20ebf0020a1709d4e0205400311c",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/HRHN/Extension/CGFloat+.swift
+++ b/HRHN/Extension/CGFloat+.swift
@@ -1,0 +1,16 @@
+//
+//  CGFloat.swift
+//  HRHN
+//
+//  Created by Chanhee Jeong on 2022/12/21.
+//
+//  ref: https://github.com/hanulyun/Autolayout-iPhone
+
+import UIKit
+
+extension CGFloat {
+    var adjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return self * ratio
+    }
+}

--- a/HRHN/Extension/CGFloat+.swift
+++ b/HRHN/Extension/CGFloat+.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension CGFloat {
     var adjusted: CGFloat {
-        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        let ratio: CGFloat = UIScreen.main.bounds.width / 390
         return self * ratio
     }
 }

--- a/HRHN/Extension/Double+.swift
+++ b/HRHN/Extension/Double+.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension Double {
     var adjusted: CGFloat {
-        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        let ratio: CGFloat = UIScreen.main.bounds.width / 390
         return CGFloat(self) * ratio
     }
 }

--- a/HRHN/Extension/Double+.swift
+++ b/HRHN/Extension/Double+.swift
@@ -1,0 +1,16 @@
+//
+//  Double+.swift
+//  HRHN
+//
+//  Created by Chanhee Jeong on 2022/12/21.
+//
+
+import UIKit
+
+extension Double {
+    var adjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.width / 375
+        return CGFloat(self) * ratio
+    }
+}
+

--- a/HRHN/Managers/DeviceManager.swift
+++ b/HRHN/Managers/DeviceManager.swift
@@ -1,0 +1,44 @@
+//
+//  DeviceManager.swift
+//  HRHN
+//
+//  Created by Chanhee Jeong on 2022/12/21.
+//
+//  ref: https://github.com/hanulyun/Autolayout-iPhone
+
+import DeviceKit
+
+public enum DeviceGroup {
+   case fourInches
+   case fiveInches
+   case notches
+   case iPads
+   public var rawValue: [Device] {
+      switch self {
+      case .fourInches:
+         return [.iPhone5s, .iPhoneSE]
+      case .fiveInches:
+        return [.iPhone6, .iPhone6s, .iPhone7, .iPhone8, .simulator(.iPhone8)]
+      case .notches:
+         return Device.allDevicesWithSensorHousing
+      case .iPads:
+         return Device.allPads
+      }
+   }
+}
+
+class DeviceManager {
+    static let shared: DeviceManager = DeviceManager()
+    
+    func isFourIncheDevices() -> Bool {
+       return Device.current.isOneOf(DeviceGroup.fourInches.rawValue)
+    }
+    
+    func isFiveIncheDevices() -> Bool {
+        return Device.current.isOneOf(DeviceGroup.fiveInches.rawValue)
+    }
+    
+    func isIPadDevices() -> Bool {
+       return Device.current.isOneOf(DeviceGroup.iPads.rawValue)
+    }
+}


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- Closes #17

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- DeviceKit SPM 추가
  - DeviceKit 을 사용하여 아이폰 버전 확인 등 앱품질관리 용이성 및 가독성이 증대되었습니다. (다이나믹아일랜드도 문제없댜이제!)

- Extension 추가 (Scroll View 용)
  - iphone 13 가로길이 390 에 맞게 비율이 변하도록 대응하였습니다
  - 앞으로 작업할때 기기별 조절이 필요한 경우 각기기 인치에서 N.adjusted 하면 쉽게 대응가능!
```swift
// 사용방법
button.contentEdgeInsets = UIEdgeInsets(inset: 5.adjusted)
```

- DeviceManager 싱글톤 추가
  - 싱글톤을 활용하여 매번 DeviceKit 을 import 하지 않아도 됩니다!
```swift
// 사용방법
DeviceManager.shared.isFourInchesDevices()
```


## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- SnapKit을 적용함에 따라 레퍼런스와는 약간의 사용방식 차이가 있을 수 있습니다
- 디자인에서 이제 4인치 모델(ex-SE), 5인치 모델(ex-iphon8)이 필요한 경우 따로 대응가능것으로 기대합니다!


## Reference
<!-- 참고한 자료를 작성해주세요 -->
- [(Swift) iPhone 해상도별 오토레이아웃을 하는 2가지 방법](https://hanulyun.medium.com/swift-iphone-%ED%95%B4%EC%83%81%EB%8F%84%EB%B3%84-%EC%98%A4%ED%86%A0%EB%A0%88%EC%9D%B4%EC%95%84%EC%9B%83%EC%9D%84-%ED%95%98%EB%8A%94-2%EA%B0%80%EC%A7%80-%EB%B0%A9%EB%B2%95-5ef1f3726d0d) 을 기반으로 작성하였습니다
- [하루하나 개발일지 - 해상도별 오토레이아웃 대응](https://www.notion.so/avery-in-ada/85cf8ff99a03471bb3dab0232333e518)


## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
