### PR TITLE
[DesignSystem] Color Asset 세팅

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		50DBEA0A2952E94400ED00FD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50DBEA092952E94400ED00FD /* Colors.xcassets */; };
 		A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D1294A0A5F0044E652 /* AppDelegate.swift */; };
 		A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D3294A0A5F0044E652 /* SceneDelegate.swift */; };
 		A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		50DBEA092952E94400ED00FD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		A79120CE294A0A5F0044E652 /* HRHN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HRHN.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A79120D1294A0A5F0044E652 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A79120D3294A0A5F0044E652 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 				A79120D1294A0A5F0044E652 /* AppDelegate.swift */,
 				A79120D3294A0A5F0044E652 /* SceneDelegate.swift */,
 				A79120DD294A0A610044E652 /* Assets.xcassets */,
+				50DBEA092952E94400ED00FD /* Colors.xcassets */,
 				A79120DF294A0A610044E652 /* LaunchScreen.storyboard */,
 				A79120E2294A0A610044E652 /* Info.plist */,
 			);
@@ -351,6 +354,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50DBEA0A2952E94400ED00FD /* Colors.xcassets in Resources */,
 				A79120E1294A0A610044E652 /* LaunchScreen.storyboard in Resources */,
 				A79120DE294A0A610044E652 /* Assets.xcassets in Resources */,
 			);

--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		50DBEA0A2952E94400ED00FD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50DBEA092952E94400ED00FD /* Colors.xcassets */; };
+		50DBEA0D2952EB4C00ED00FD /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DBEA0C2952EB4C00ED00FD /* Color.swift */; };
+		50DBEA0F2952EBC300ED00FD /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DBEA0E2952EBC300ED00FD /* UIColor+.swift */; };
 		A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D1294A0A5F0044E652 /* AppDelegate.swift */; };
 		A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D3294A0A5F0044E652 /* SceneDelegate.swift */; };
 		A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
@@ -52,6 +54,8 @@
 
 /* Begin PBXFileReference section */
 		50DBEA092952E94400ED00FD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		50DBEA0C2952EB4C00ED00FD /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		50DBEA0E2952EBC300ED00FD /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		A79120CE294A0A5F0044E652 /* HRHN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HRHN.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A79120D1294A0A5F0044E652 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A79120D3294A0A5F0044E652 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -106,6 +110,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		50DBEA0B2952EB3B00ED00FD /* Color */ = {
+			isa = PBXGroup;
+			children = (
+				50DBEA0C2952EB4C00ED00FD /* Color.swift */,
+				50DBEA0E2952EBC300ED00FD /* UIColor+.swift */,
+			);
+			path = Color;
+			sourceTree = "<group>";
+		};
 		A79120C5294A0A5F0044E652 = {
 			isa = PBXGroup;
 			children = (
@@ -134,6 +147,7 @@
 				A7912111294B1A590044E652 /* Model */,
 				A791210E294B1A2A0044E652 /* ViewModel */,
 				A791210D294B1A230044E652 /* View */,
+				50DBEA0B2952EB3B00ED00FD /* Color */,
 				A79120D1294A0A5F0044E652 /* AppDelegate.swift */,
 				A79120D3294A0A5F0044E652 /* SceneDelegate.swift */,
 				A79120DD294A0A610044E652 /* Assets.xcassets */,
@@ -385,6 +399,7 @@
 				A791210C294B190E0044E652 /* TodayViewController.swift in Sources */,
 				A7912117294B1AB40044E652 /* SampleRepository.swift in Sources */,
 				A79121272950D12A0044E652 /* TabBarController.swift in Sources */,
+				50DBEA0D2952EB4C00ED00FD /* Color.swift in Sources */,
 				A79121292950D2000044E652 /* RecordViewController.swift in Sources */,
 				A791211F294B1B0A0044E652 /* SampleViewModel.swift in Sources */,
 				A7912115294B1AAB0044E652 /* SampleModel.swift in Sources */,
@@ -397,6 +412,7 @@
 				A7912121294B1B440044E652 /* CoreDataManager.swift in Sources */,
 				A791214F295228530044E652 /* Double+.swift in Sources */,
 				A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */,
+				50DBEA0F2952EBC300ED00FD /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HRHN/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/HRHN/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/HRHN/Color/Color.swift
+++ b/HRHN/Color/Color.swift
@@ -1,0 +1,35 @@
+//
+//  Color.swift
+//  HRHN
+//
+//  Created by 민채호 on 2022/12/21.
+//
+
+import Foundation
+
+public enum Color: String {
+    
+    case white
+    case black
+    
+    case grayFB
+    case grayF6
+    case grayD4
+    case grayC5
+    case gray81
+    case gray54
+    case gray4A
+    
+    case red01
+    case red02
+    
+    case yellow01
+    
+    case green01
+    
+    case skyblue01
+    
+    case blue01
+    
+    case purple01
+}

--- a/HRHN/Color/Color.swift
+++ b/HRHN/Color/Color.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Color: String {
+enum Color: String {
     
     case white
     case black

--- a/HRHN/Color/UIColor+.swift
+++ b/HRHN/Color/UIColor+.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public extension UIColor {
+extension UIColor {
     static func resolvedColor(_ color: Color) -> UIColor? {
         return UIColor(named: color.rawValue)
     }
@@ -28,7 +28,7 @@ public extension UIColor {
 
 // MARK: - Semantic Colors
 
-public extension UIColor {
+extension UIColor {
     
     static let background = resolvedColor(.white)
     

--- a/HRHN/Color/UIColor+.swift
+++ b/HRHN/Color/UIColor+.swift
@@ -1,0 +1,55 @@
+//
+//  UIColor+.swift
+//  HRHN
+//
+//  Created by 민채호 on 2022/12/21.
+//
+
+import UIKit
+
+public extension UIColor {
+    static func resolvedColor(_ color: Color) -> UIColor? {
+        return UIColor(named: color.rawValue)
+    }
+    
+    static func appearanceColor(light: Color, dark: Color) -> UIColor {
+        UIColor { traitCollection in
+            switch traitCollection.userInterfaceStyle {
+            case .light, .unspecified:
+                return resolvedColor(light)!
+            case .dark:
+                return resolvedColor(dark)!
+            @unknown default:
+                return resolvedColor(light)!
+            }
+        }
+    }
+}
+
+// MARK: - Semantic Colors
+
+public extension UIColor {
+    
+    static let background = resolvedColor(.white)
+    
+    static let reverseLabel = appearanceColor(light: .white, dark: .black)
+    
+    static let disabled = resolvedColor(.grayD4)
+    static let dim = resolvedColor(.gray54)
+    
+    static let point = resolvedColor(.red02)
+    
+    static let challengeCardFill = resolvedColor(.grayFB)
+    static let challengeCardLabel = resolvedColor(.gray4A)
+    static let challngeListFill = resolvedColor(.grayF6)
+    static let challengeListLabel = resolvedColor(.gray81)
+    static let settingIconFill = resolvedColor(.grayC5)
+    
+    static let emojiRed = resolvedColor(.red01)
+    static let emojiYellow = resolvedColor(.yellow01)
+    static let emojiGreen = resolvedColor(.green01)
+    static let emojiSkyblue = resolvedColor(.skyblue01)
+    static let emojiBlue = resolvedColor(.blue01)
+    static let emojiPurple = resolvedColor(.purple01)
+}
+

--- a/HRHN/Colors.xcassets/Contents.json
+++ b/HRHN/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/Contents.json
+++ b/HRHN/Colors.xcassets/gray/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/gray4A.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/gray4A.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4A",
+          "green" : "0x4A",
+          "red" : "0x4A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/gray54.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/gray54.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x54",
+          "green" : "0x54",
+          "red" : "0x54"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/gray81.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/gray81.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x81",
+          "green" : "0x81",
+          "red" : "0x81"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/grayC5.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/grayC5.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC5",
+          "green" : "0xC5",
+          "red" : "0xC5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/grayD4.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/grayD4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD4",
+          "green" : "0xD4",
+          "red" : "0xD4"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/grayF6.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/grayF6.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF6",
+          "red" : "0xF6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/gray/grayFB.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/gray/grayFB.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFB",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/green/Contents.json
+++ b/HRHN/Colors.xcassets/green/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/green/green01.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/green/green01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x80",
+          "green" : "0xDE",
+          "red" : "0xAC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/pure/Contents.json
+++ b/HRHN/Colors.xcassets/pure/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/pure/black.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/pure/black.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/pure/white.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/pure/white.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/purple/Contents.json
+++ b/HRHN/Colors.xcassets/purple/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/purple/purple01.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/purple/purple01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xBA",
+          "red" : "0xE1"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/red/Contents.json
+++ b/HRHN/Colors.xcassets/red/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/red/red01.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/red/red01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAC",
+          "green" : "0xBB",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/red/red02.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/red/red02.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.275",
+          "green" : "0.376",
+          "red" : "0.863"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/skyblue/Contents.json
+++ b/HRHN/Colors.xcassets/skyblue/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/skyblue/skyblue01.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/skyblue/skyblue01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFE",
+          "green" : "0xB4",
+          "red" : "0x97"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/yellow/Contents.json
+++ b/HRHN/Colors.xcassets/yellow/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Colors.xcassets/yellow/yellow01.colorset/Contents.json
+++ b/HRHN/Colors.xcassets/yellow/yellow01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x77",
+          "green" : "0xD9",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/HRHN/Info.plist
+++ b/HRHN/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #4 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- Info.plist 수정
    - 버전 1.0에서는 빠른 개발 시작을 위해 다크모드를 버렸습니다!😅
- Color Asset 추가
    - Base Colors를 Asset으로 추가했습니다.
- UIColor Extension 추가
    - appearanceColor 메서드를 추가하여 다음 버전에 다크모드를 바로 적용할 수 있도록 세팅을 완료했습니다.
    - Semantic Colors를 추가했습니다.

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- Color.swift 파일을 어디다 둬야 할지 모르겠어서 Color랑 UIColor+ 파일을 Color 폴더를 만들어서 그 안에 넣었습니다. 파일 위치 수정이 필요하면 말해주세요.

## 기타
- 사용법은 레퍼런스 링크 참고해주세요.
- 지금 코드가 다 public인데, public일 필요가 없어서 집에 가서 제거하겠습니다😅 지금 밖이라서;;

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- [[DesignSystem] ZESTY Design System - 색상(+다크모드) + 폰트 시스템 사용법 및 구축기](https://github.com/DeveloperAcademy-POSTECH/MacC-TEAM-ZESTY/discussions/92)

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
