### PR TITLE
[Feat] 락스크린 위젯

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 		507089AF295ABC2B00DD8D85 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		507089B1295ADE1A00DD8D85 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
+		50A5000B295D8B8300710B5D /* HRHN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HRHN.entitlements; sourceTree = "<group>"; };
+		50A5000C295D8BAD00710B5D /* LockscreenWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LockscreenWidgetExtension.entitlements; sourceTree = "<group>"; };
 		50A5FFEA295D765700710B5D /* AddViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddViewController.swift; sourceTree = "<group>"; };
 		50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LockscreenWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		50A5FFF2295D784A00710B5D /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -244,6 +246,7 @@
 		A79120C5294A0A5F0044E652 = {
 			isa = PBXGroup;
 			children = (
+				50A5000C295D8BAD00710B5D /* LockscreenWidgetExtension.entitlements */,
 				A79120D0294A0A5F0044E652 /* HRHN */,
 				A79120EA294A0A610044E652 /* HRHNTests */,
 				A79120F4294A0A610044E652 /* HRHNUITests */,
@@ -267,6 +270,7 @@
 		A79120D0294A0A5F0044E652 /* HRHN */ = {
 			isa = PBXGroup;
 			children = (
+				50A5000B295D8B8300710B5D /* HRHN.entitlements */,
 				A7912187295775D50044E652 /* Helper */,
 				A7912149295227140044E652 /* Managers */,
 				A791210F294B1A3A0044E652 /* Extension */,
@@ -682,9 +686,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = LockscreenWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 562Z37RH3N;
+				DEVELOPMENT_TEAM = T378897HQ2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LockscreenWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LockscreenWidget;
@@ -709,9 +714,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = LockscreenWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 562Z37RH3N;
+				DEVELOPMENT_TEAM = T378897HQ2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LockscreenWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LockscreenWidget;
@@ -851,9 +857,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = HRHN/HRHN.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 562Z37RH3N;
+				DEVELOPMENT_TEAM = T378897HQ2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HRHN/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -880,9 +887,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = HRHN/HRHN.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 562Z37RH3N;
+				DEVELOPMENT_TEAM = T378897HQ2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = HRHN/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -14,6 +14,13 @@
 		507089B2295ADE1A00DD8D85 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B1295ADE1A00DD8D85 /* View+.swift */; };
 		507089B4295AE9D600DD8D85 /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */; };
 		50A50001295D784B00710B5D /* LockscreenWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		50A5000F295D8FD100710B5D /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
+		50A50010295D903D00710B5D /* Challenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912114294B1AAB0044E652 /* Challenge.swift */; };
+		50A50011295D908500710B5D /* ChallengeMO+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121602954C2D60044E652 /* ChallengeMO+CoreDataClass.swift */; };
+		50A50012295D908800710B5D /* ChallengeMO+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121612954C2D60044E652 /* ChallengeMO+CoreDataProperties.swift */; };
+		50A50013295D91AC00710B5D /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912120294B1B440044E652 /* CoreDataManager.swift */; };
+		50A50017295D951600710B5D /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A50016295D951600710B5D /* URL+.swift */; };
+		50A50018295D953200710B5D /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A50016295D951600710B5D /* URL+.swift */; };
 		50A5FFEB295D765700710B5D /* AddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A5FFEA295D765700710B5D /* AddViewController.swift */; };
 		50A5FFF3295D784A00710B5D /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A5FFF2295D784A00710B5D /* WidgetKit.framework */; };
 		50A5FFF5295D784A00710B5D /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A5FFF4295D784A00710B5D /* SwiftUI.framework */; };
@@ -109,6 +116,7 @@
 		507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
 		50A5000B295D8B8300710B5D /* HRHN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HRHN.entitlements; sourceTree = "<group>"; };
 		50A5000C295D8BAD00710B5D /* LockscreenWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LockscreenWidgetExtension.entitlements; sourceTree = "<group>"; };
+		50A50016295D951600710B5D /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
 		50A5FFEA295D765700710B5D /* AddViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddViewController.swift; sourceTree = "<group>"; };
 		50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LockscreenWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		50A5FFF2295D784A00710B5D /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -325,6 +333,7 @@
 				505B953729599976005F00C8 /* UIViewController+.swift */,
 				507089B1295ADE1A00DD8D85 /* View+.swift */,
 				50C1BE39295C7539009A57BA /* UITextView+.swift */,
+				50A50016295D951600710B5D /* URL+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -582,7 +591,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				50A5FFF8295D784A00710B5D /* LockscreenWidget.swift in Sources */,
+				50A50011295D908500710B5D /* ChallengeMO+CoreDataClass.swift in Sources */,
+				50A50012295D908800710B5D /* ChallengeMO+CoreDataProperties.swift in Sources */,
+				50A50018295D953200710B5D /* URL+.swift in Sources */,
+				50A5000F295D8FD100710B5D /* HRHN.xcdatamodeld in Sources */,
 				50A5FFFD295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */,
+				50A50013295D91AC00710B5D /* CoreDataManager.swift in Sources */,
+				50A50010295D903D00710B5D /* Challenge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -625,6 +640,7 @@
 				A7912121294B1B440044E652 /* CoreDataManager.swift in Sources */,
 				A791214F295228530044E652 /* Double+.swift in Sources */,
 				50C1BE3A295C7539009A57BA /* UITextView+.swift in Sources */,
+				50A50017295D951600710B5D /* URL+.swift in Sources */,
 				A791217D2956037B0044E652 /* ChallengeCell.swift in Sources */,
 				A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */,
 				50DBEA0F2952EBC300ED00FD /* UIColor+.swift in Sources */,

--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -13,7 +13,14 @@
 		507089B0295ABC2B00DD8D85 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089AF295ABC2B00DD8D85 /* Color+.swift */; };
 		507089B2295ADE1A00DD8D85 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B1295ADE1A00DD8D85 /* View+.swift */; };
 		507089B4295AE9D600DD8D85 /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */; };
+		50A50001295D784B00710B5D /* LockscreenWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		50A5FFEB295D765700710B5D /* AddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A5FFEA295D765700710B5D /* AddViewController.swift */; };
+		50A5FFF3295D784A00710B5D /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A5FFF2295D784A00710B5D /* WidgetKit.framework */; };
+		50A5FFF5295D784A00710B5D /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A5FFF4295D784A00710B5D /* SwiftUI.framework */; };
+		50A5FFF8295D784A00710B5D /* LockscreenWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A5FFF7295D784A00710B5D /* LockscreenWidget.swift */; };
+		50A5FFFB295D784B00710B5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50A5FFFA295D784B00710B5D /* Assets.xcassets */; };
+		50A5FFFD295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 50A5FFF9295D784A00710B5D /* LockscreenWidget.intentdefinition */; };
+		50A5FFFE295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 50A5FFF9295D784A00710B5D /* LockscreenWidget.intentdefinition */; };
 		50BD589E29580C3E009F9556 /* UIFullWidthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BD589D29580C3E009F9556 /* UIFullWidthButton.swift */; };
 		50BD58A029587240009F9556 /* FullWidthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BD589F29587240009F9556 /* FullWidthButton.swift */; };
 		50C1BE3A295C7539009A57BA /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C1BE39295C7539009A57BA /* UITextView+.swift */; };
@@ -56,6 +63,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		50A5FFFF295D784B00710B5D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A79120C6294A0A5F0044E652 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 50A5FFEF295D784A00710B5D;
+			remoteInfo = LockscreenWidgetExtension;
+		};
 		A79120E8294A0A610044E652 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A79120C6294A0A5F0044E652 /* Project object */;
@@ -72,6 +86,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		50A50005295D784B00710B5D /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				50A50001295D784B00710B5D /* LockscreenWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		505B95342959926A005F00C8 /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
 		505B953729599976005F00C8 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
@@ -80,6 +108,13 @@
 		507089B1295ADE1A00DD8D85 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
 		50A5FFEA295D765700710B5D /* AddViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddViewController.swift; sourceTree = "<group>"; };
+		50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LockscreenWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		50A5FFF2295D784A00710B5D /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		50A5FFF4295D784A00710B5D /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		50A5FFF7295D784A00710B5D /* LockscreenWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockscreenWidget.swift; sourceTree = "<group>"; };
+		50A5FFF9295D784A00710B5D /* LockscreenWidget.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = LockscreenWidget.intentdefinition; sourceTree = "<group>"; };
+		50A5FFFA295D784B00710B5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		50A5FFFC295D784B00710B5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50BD589D29580C3E009F9556 /* UIFullWidthButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFullWidthButton.swift; sourceTree = "<group>"; };
 		50BD589F29587240009F9556 /* FullWidthButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthButton.swift; sourceTree = "<group>"; };
 		50C1BE39295C7539009A57BA /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
@@ -124,6 +159,15 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		50A5FFED295D784A00710B5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50A5FFF5295D784A00710B5D /* SwiftUI.framework in Frameworks */,
+				50A5FFF3295D784A00710B5D /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A79120CB294A0A5F0044E652 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -158,6 +202,26 @@
 			path = SwiftUIView;
 			sourceTree = "<group>";
 		};
+		50A5FFF1295D784A00710B5D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				50A5FFF2295D784A00710B5D /* WidgetKit.framework */,
+				50A5FFF4295D784A00710B5D /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		50A5FFF6295D784A00710B5D /* LockscreenWidget */ = {
+			isa = PBXGroup;
+			children = (
+				50A5FFF7295D784A00710B5D /* LockscreenWidget.swift */,
+				50A5FFF9295D784A00710B5D /* LockscreenWidget.intentdefinition */,
+				50A5FFFA295D784B00710B5D /* Assets.xcassets */,
+				50A5FFFC295D784B00710B5D /* Info.plist */,
+			);
+			path = LockscreenWidget;
+			sourceTree = "<group>";
+		};
 		50BD589C29580C35009F9556 /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -183,6 +247,8 @@
 				A79120D0294A0A5F0044E652 /* HRHN */,
 				A79120EA294A0A610044E652 /* HRHNTests */,
 				A79120F4294A0A610044E652 /* HRHNUITests */,
+				50A5FFF6295D784A00710B5D /* LockscreenWidget */,
+				50A5FFF1295D784A00710B5D /* Frameworks */,
 				A79120CF294A0A5F0044E652 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -193,6 +259,7 @@
 				A79120CE294A0A5F0044E652 /* HRHN.app */,
 				A79120E7294A0A610044E652 /* HRHNTests.xctest */,
 				A79120F1294A0A610044E652 /* HRHNUITests.xctest */,
+				50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -343,6 +410,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		50A5FFEF295D784A00710B5D /* LockscreenWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 50A50002295D784B00710B5D /* Build configuration list for PBXNativeTarget "LockscreenWidgetExtension" */;
+			buildPhases = (
+				50A5FFEC295D784A00710B5D /* Sources */,
+				50A5FFED295D784A00710B5D /* Frameworks */,
+				50A5FFEE295D784A00710B5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LockscreenWidgetExtension;
+			productName = LockscreenWidgetExtension;
+			productReference = 50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		A79120CD294A0A5F0044E652 /* HRHN */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A79120FB294A0A610044E652 /* Build configuration list for PBXNativeTarget "HRHN" */;
@@ -350,10 +434,12 @@
 				A79120CA294A0A5F0044E652 /* Sources */,
 				A79120CB294A0A5F0044E652 /* Frameworks */,
 				A79120CC294A0A5F0044E652 /* Resources */,
+				50A50005295D784B00710B5D /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				50A50000295D784B00710B5D /* PBXTargetDependency */,
 			);
 			name = HRHN;
 			packageProductDependencies = (
@@ -410,6 +496,9 @@
 				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
+					50A5FFEF295D784A00710B5D = {
+						CreatedOnToolsVersion = 14.0.1;
+					};
 					A79120CD294A0A5F0044E652 = {
 						CreatedOnToolsVersion = 14.0;
 					};
@@ -443,11 +532,20 @@
 				A79120CD294A0A5F0044E652 /* HRHN */,
 				A79120E6294A0A610044E652 /* HRHNTests */,
 				A79120F0294A0A610044E652 /* HRHNUITests */,
+				50A5FFEF295D784A00710B5D /* LockscreenWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		50A5FFEE295D784A00710B5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50A5FFFB295D784B00710B5D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A79120CC294A0A5F0044E652 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -475,6 +573,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		50A5FFEC295D784A00710B5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50A5FFF8295D784A00710B5D /* LockscreenWidget.swift in Sources */,
+				50A5FFFD295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A79120CA294A0A5F0044E652 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -482,6 +589,7 @@
 				A7ED3EF8295C2FEF00342CC8 /* SettingCell.swift in Sources */,
 				A791214D295228200044E652 /* CGFloat+.swift in Sources */,
 				A79121622954C2D60044E652 /* ChallengeMO+CoreDataClass.swift in Sources */,
+				50A5FFFE295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */,
 				505B953829599976005F00C8 /* UIViewController+.swift in Sources */,
 				A79121792955FBCE0044E652 /* CustomColor.swift in Sources */,
 				A791210C294B190E0044E652 /* TodayViewController.swift in Sources */,
@@ -540,6 +648,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		50A50000295D784B00710B5D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 50A5FFEF295D784A00710B5D /* LockscreenWidgetExtension */;
+			targetProxy = 50A5FFFF295D784B00710B5D /* PBXContainerItemProxy */;
+		};
 		A79120E9294A0A610044E652 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A79120CD294A0A5F0044E652 /* HRHN */;
@@ -564,6 +677,60 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		50A50003295D784B00710B5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LockscreenWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LockscreenWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHN.LockscreenWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		50A50004295D784B00710B5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 562Z37RH3N;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LockscreenWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = LockscreenWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.chanheejeong.HRHN.LockscreenWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		A79120F9294A0A610044E652 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -681,6 +848,7 @@
 		A79120FC294A0A610044E652 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -709,6 +877,7 @@
 		A79120FD294A0A610044E652 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -813,6 +982,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		50A50002295D784B00710B5D /* Build configuration list for PBXNativeTarget "LockscreenWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				50A50003295D784B00710B5D /* Debug */,
+				50A50004295D784B00710B5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A79120C9294A0A5F0044E652 /* Build configuration list for PBXProject "HRHN" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/HRHN/AppDelegate.swift
+++ b/HRHN/AppDelegate.swift
@@ -25,51 +25,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
     }
-
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-        */
-        let container = NSPersistentContainer(name: "HRHN")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                 
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-
 }
 

--- a/HRHN/Extension/URL+.swift
+++ b/HRHN/Extension/URL+.swift
@@ -1,0 +1,18 @@
+//
+//  URL+.swift
+//  HRHN
+//
+//  Created by 민채호 on 2022/12/29.
+//
+
+import Foundation
+
+extension URL {
+    static func storeURL(for appGroup: String, databaseName: String) -> URL {
+        guard let fileContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
+            fatalError("Shared file container could not be created.")
+        }
+
+        return fileContainer.appendingPathComponent("\(databaseName).sqlite")
+    }
+}

--- a/HRHN/HRHN.entitlements
+++ b/HRHN/HRHN.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.chanheejeong.HRHN</string>
+	</array>
+</dict>
+</plist>

--- a/HRHN/Managers/CoreDataManager.swift
+++ b/HRHN/Managers/CoreDataManager.swift
@@ -13,12 +13,23 @@ class CoreDataManager {
     
     static var shared: CoreDataManager = CoreDataManager()
     
-    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
-    private lazy var context = appDelegate?.persistentContainer.viewContext
+    private let persistentContainer: NSPersistentContainer = {
+        let appGroundID = "group.com.chanheejeong.HRHN"
+        let storeURL = URL.storeURL(for: appGroundID, databaseName: "HRHN")
+        let storeDescription = NSPersistentStoreDescription(url: storeURL)
+        let container = NSPersistentContainer(name: "HRHN")
+        container.persistentStoreDescriptions = [storeDescription]
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    private lazy var context = persistentContainer.viewContext
     
     func insertChallenge(_ challenge: Challenge) {
-        guard let context = self.context,
-              let entity = NSEntityDescription.entity(forEntityName: "Challenge", in: context) else { return }
+        guard let entity = NSEntityDescription.entity(forEntityName: "Challenge", in: context) else { return }
         
         let existing = getChallengeOf(challenge.date)
         if existing.isEmpty {
@@ -38,8 +49,6 @@ class CoreDataManager {
     }
     
     private func fetchChallenges() -> [ChallengeMO] {
-        
-        guard let context = self.context else { return [] }
         
         let fetchRequest = NSFetchRequest<ChallengeMO>(entityName: "Challenge")
         let sort = NSSortDescriptor(key: #keyPath(ChallengeMO.date), ascending: false) // by latest
@@ -76,7 +85,11 @@ class CoreDataManager {
                 result.content = challenge.content
             }
         }
-        appDelegate?.saveContext()
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
     }
     
     
@@ -100,12 +113,15 @@ class CoreDataManager {
     }
     
     func deleteChallenge(_ date: Date) {
-        guard let context = self.context else { return }
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
             let challenge = fetchResults.filter({ isSameDay(date1: date, date2: $0.date) })[0]
             context.delete(challenge)
-            appDelegate?.saveContext()
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
         } else {
             // TODO: - 에러처리
             print("삭제할 데이터가 없습니다.")
@@ -113,13 +129,16 @@ class CoreDataManager {
     }
     
     func deleteAllChallenges() {
-        guard let context = self.context else { return }
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
             for result in fetchResults {
                 context.delete(result)
             }
-            appDelegate?.saveContext()
+            do {
+                try context.save()
+            } catch {
+                print(error.localizedDescription)
+            }
         } else {
             // TODO: - 에러처리
             print("삭제할 데이터가 없습니다.")

--- a/HRHN/Managers/CoreDataManager.swift
+++ b/HRHN/Managers/CoreDataManager.swift
@@ -26,7 +26,22 @@ class CoreDataManager {
         })
         return container
     }()
+    
     private lazy var context = persistentContainer.viewContext
+    
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
     
     func insertChallenge(_ challenge: Challenge) {
         guard let entity = NSEntityDescription.entity(forEntityName: "Challenge", in: context) else { return }

--- a/HRHN/SceneDelegate.swift
+++ b/HRHN/SceneDelegate.swift
@@ -33,8 +33,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
-//        CoreDataManager.shared.saveToContext()
+        CoreDataManager.shared.saveContext()
     }
 
 

--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -169,6 +169,7 @@ private extension AddViewController {
     
     func doneButtonDidTap() {
         self.viewModel.createChallenge(self.addChallengeTextView.text as String)
+        self.viewModel.updateWidget()
         self.navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/HRHN/ViewModel/AddViewModel.swift
+++ b/HRHN/ViewModel/AddViewModel.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import WidgetKit
 
 final class AddViewModel: ObservableObject {
     
     private let coreDataManager = CoreDataManager.shared
+    private let widgetCenter = WidgetCenter.shared
     
     init() {}
     
@@ -20,5 +22,9 @@ final class AddViewModel: ObservableObject {
             content: content,
             emoji: .none)
         )
+    }
+    
+    func updateWidget() {
+        widgetCenter.reloadAllTimelines()
     }
 }

--- a/LockscreenWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/LockscreenWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LockscreenWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/LockscreenWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LockscreenWidget/Assets.xcassets/Contents.json
+++ b/LockscreenWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LockscreenWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/LockscreenWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LockscreenWidget/Info.plist
+++ b/LockscreenWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/LockscreenWidget/LockscreenWidget.intentdefinition
+++ b/LockscreenWidget/LockscreenWidget.intentdefinition
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>INEnums</key>
+	<array/>
+	<key>INIntentDefinitionModelVersion</key>
+	<string>1.2</string>
+	<key>INIntentDefinitionNamespace</key>
+	<string>88xZPY</string>
+	<key>INIntentDefinitionSystemVersion</key>
+	<string>20A294</string>
+	<key>INIntentDefinitionToolsBuildVersion</key>
+	<string>12A6144</string>
+	<key>INIntentDefinitionToolsVersion</key>
+	<string>12.0</string>
+	<key>INIntents</key>
+	<array>
+		<dict>
+			<key>INIntentCategory</key>
+			<string>information</string>
+			<key>INIntentDescriptionID</key>
+			<string>tVvJ9c</string>
+			<key>INIntentEligibleForWidgets</key>
+			<true/>
+			<key>INIntentIneligibleForSuggestions</key>
+			<true/>
+			<key>INIntentName</key>
+			<string>Configuration</string>
+			<key>INIntentResponse</key>
+			<dict>
+				<key>INIntentResponseCodes</key>
+				<array>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>success</string>
+						<key>INIntentResponseCodeSuccess</key>
+						<true/>
+					</dict>
+					<dict>
+						<key>INIntentResponseCodeName</key>
+						<string>failure</string>
+					</dict>
+				</array>
+			</dict>
+			<key>INIntentTitle</key>
+			<string>Configuration</string>
+			<key>INIntentTitleID</key>
+			<string>gpCwrM</string>
+			<key>INIntentType</key>
+			<string>Custom</string>
+			<key>INIntentVerb</key>
+			<string>View</string>
+		</dict>
+	</array>
+	<key>INTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -69,8 +69,8 @@ struct LockscreenWidget: Widget {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
             LockscreenWidgetEntryView(entry: entry)
         }
-        .configurationDisplayName("My Widget")
-        .description("This is an example widget.")
+        .configurationDisplayName("오늘의 챌린지")
+        .description("오늘의 챌린지를 볼 수 있습니다.")
         .supportedFamilies([
             .accessoryRectangular
         ])

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -1,0 +1,79 @@
+//
+//  LockscreenWidget.swift
+//  LockscreenWidget
+//
+//  Created by 민채호 on 2022/12/29.
+//
+
+import WidgetKit
+import SwiftUI
+import Intents
+
+struct Provider: IntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationIntent())
+    }
+
+    func getSnapshot(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+        let entry = SimpleEntry(date: Date(), configuration: configuration)
+        completion(entry)
+    }
+
+    func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        let timeline = Timeline(entries: entries, policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationIntent
+}
+
+struct LockscreenWidgetEntryView : View {
+    @Environment(\.widgetFamily) var widgetFamily
+    var entry: Provider.Entry
+
+    var body: some View {
+        switch widgetFamily {
+        case .accessoryRectangular:
+            Text("대충 30자 제한하면 위젯에서도 안잘릴듯 이게 대략 30자")
+        default:
+            Text("Not Implemented")
+        }
+    }
+}
+
+@main
+struct LockscreenWidget: Widget {
+    let kind: String = "LockscreenWidget"
+
+    var body: some WidgetConfiguration {
+        IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: Provider()) { entry in
+            LockscreenWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("My Widget")
+        .description("This is an example widget.")
+        .supportedFamilies([
+            .accessoryRectangular
+        ])
+    }
+}
+
+struct LockscreenWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        LockscreenWidgetEntryView(entry: SimpleEntry(date: Date(), configuration: ConfigurationIntent()))
+            .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+            .previewDisplayName("Rectangular")
+    }
+}

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -22,15 +22,21 @@ struct Provider: IntentTimelineProvider {
     func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
         var entries: [SimpleEntry] = []
 
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
         let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, configuration: configuration)
-            entries.append(entry)
-        }
-
-        let timeline = Timeline(entries: entries, policy: .atEnd)
+        let midnight = Calendar.current.startOfDay(for: currentDate)
+        let nextMidnight = Calendar.current.date(
+            byAdding: .day,
+            value: 1,
+            to: midnight
+        )!
+        
+        let entry = SimpleEntry(
+            date: currentDate,
+            configuration: configuration
+        )
+        entries.append(entry)
+        
+        let timeline = Timeline(entries: entries, policy: .after(nextMidnight))
         completion(timeline)
     }
 }

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -70,7 +70,7 @@ struct LockscreenWidget: Widget {
             LockscreenWidgetEntryView(entry: entry)
         }
         .configurationDisplayName("오늘의 챌린지")
-        .description("오늘의 챌린지를 볼 수 있습니다.")
+        .description("오늘의 챌린지를 확인합니다.")
         .supportedFamilies([
             .accessoryRectangular
         ])

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -43,11 +43,18 @@ struct SimpleEntry: TimelineEntry {
 struct LockscreenWidgetEntryView : View {
     @Environment(\.widgetFamily) var widgetFamily
     var entry: Provider.Entry
-
+    
+    private let coreDataManager = CoreDataManager.shared
+    
     var body: some View {
         switch widgetFamily {
         case .accessoryRectangular:
-            Text("대충 30자 제한하면 위젯에서도 안잘릴듯 이게 대략 30자")
+            let todayChallenge = coreDataManager.getChallengeOf(Date())
+            if todayChallenge.count > 0 {
+                Text(todayChallenge[0].content)
+            } else {
+                Text("오늘의 챌린지를 등록하세요")
+            }
         default:
             Text("Not Implemented")
         }

--- a/LockscreenWidgetExtension.entitlements
+++ b/LockscreenWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.chanheejeong.HRHN</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #11 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- .accessoryRectangular 타입의 락스크린 위젯 추가
- WidgetExtension에서도 코어데이터를 사용하기 위한 작업
    - App Group 생성
    - CoreData 관련 파일들 target에 WidgetExtension 추가
    - CoreDataManager 수정
- 위젯 업데이트 로직 추가
    - 챌린지 작성 후 완료 버튼을 눌렀을 때 업데이트

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|위젯|추가화면|
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/75792767/209955297-26fd855f-2751-4f1f-94c4-d3ccffe54b69.png">|<img width="250" src="https://user-images.githubusercontent.com/75792767/209955306-96c11e0a-1fda-4b8e-8ccf-a60ef30785fd.png">|

|챌린지 등록시 업데이트|
|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/75792767/209955318-9802bd88-4b75-496c-8df3-232aa3fd5dce.gif">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- b18c0bc WidgetExtension에서 사용하기 위해 CoreDataManager를 수정했습니다.
    - WidgetExtension에는 AppDelegate가 없기 때문에 기존의 `private lazy var context = appDelegate?.persistentContainer.viewContext` 부분에서 에러가 났습니다.
    - 따라서 해당 부분 제거 후 persistentContainer를 앱 그룹에서 가져왔습니다.
    - appDelegate 제거에 따라 기존에 있던 `appDelegate?.saveContext()` 부분을 모두 `try context.save()`로 변경했습니다.
- 위젯의 업데이트 시기를 두 가지로 잡았습니다.
    - b8c911a 하루가 지나 챌린지가 초기화됐을때
    - 7c96af1 챌린지 추가를 완료했을 때
- App Group 적용을 위해 잠시 Team을 제 계정으로 바꿨는데, 혹시 Team 계정 다시 바꿨을 때 안되면 어떡하죠...? 일단 확인 부탁드립니다.

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- [하루하나 개발일지 - Lockscreen Widget과 App Extension에서 코어데이터 사용하기](https://www.notion.so/avery-in-ada/Lockscreen-Widget-d11830d7cbab40a4818b711fb3d960ba)
- [Fetch data from CoreData for iOS 14 widget](https://stackoverflow.com/questions/63936425/fetch-data-from-coredata-for-ios-14-widget)
- [[UserDefaults] App과 Extension간 UserDefaults 공유하기](https://eunjin3786.tistory.com/213)
- [iOS Share CoreData with Extension and App Groups](https://medium.com/@pietromessineo/ios-share-coredata-with-extension-and-app-groups-69f135628736)
- [How to change view on midnight in WidgetKit, SwiftUI?](https://stackoverflow.com/questions/64209612/how-to-change-view-on-midnight-in-widgetkit-swiftui)
- [[iOS] WidgetKit 공식 문서 내용정리](https://duwjdtn11.tistory.com/572)
- [[WidgetKit] TimeLineProvider와 WidgetCenter](https://eunjin3786.tistory.com/210)

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [ ] ~Xcode Team none 으로 되어있는지 확인~ App Group 때문에 변경함!
