### PR TITLE
[Bug] 아무것도 작성하지 않은 챌린지를 추가할 수 있는 버그

### DIFF
--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -40,6 +40,7 @@ final class AddViewController: UIViewController {
     private lazy var doneButton: UIFullWidthButton = {
         $0.title = "완료"
         $0.isOnKeyboard = true
+        $0.isEnabled = false
         $0.action = UIAction { _ in
             self.doneButtonDidTap()
         }
@@ -180,9 +181,11 @@ extension AddViewController: UITextViewDelegate {
         if textView.text.isEmpty {
             placeholderLabel.isHidden = false
             textView.tintColor = .clear
+            doneButton.isEnabled = false
         } else {
             placeholderLabel.isHidden = true
             textView.tintColor = .tintColor
+            doneButton.isEnabled = true
         }
     }
     


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #47 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 챌린지 작성 텍스트가 비어있으면 완료 버튼이 비활성화되도록 수정
<img width="250" src="https://user-images.githubusercontent.com/75792767/209965118-dc8a15ae-2a1e-4053-8f3a-8b050cb2d977.gif">

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
