### PR TITLE
[Bug] 글자수 제한 추가

### DIFF
--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -25,10 +25,12 @@ final class AddViewController: UIViewController {
         .baselineOffset: 2
     ]
     
+    private let maxTextLength = 50
+    
     private var currentTextLength: Int = 0 {
         didSet {
             textLengthIndicatorLabel.attributedText = NSAttributedString(
-                string: "\(currentTextLength)/30",
+                string: "\(currentTextLength)/\(maxTextLength)",
                 attributes: lengthTextAttributes
             )
         }
@@ -94,7 +96,7 @@ final class AddViewController: UIViewController {
     
     private lazy var textLengthIndicatorLabel: UILabel = {
         $0.attributedText = NSAttributedString(
-            string: "\(currentTextLength)/30",
+            string: "\(currentTextLength)/\(maxTextLength)",
             attributes: lengthTextAttributes
         )
         $0.layer.opacity = 0.7
@@ -218,7 +220,7 @@ extension AddViewController: UITextViewDelegate {
             doneButton.isEnabled = true
         }
         
-        if textView.text.count > 30 {
+        if textView.text.count > maxTextLength {
             textView.text.removeLast()
         }
         

--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -13,11 +13,26 @@ final class AddViewController: UIViewController {
     
     private let viewModel: AddViewModel
     
-    private let attributes: [NSAttributedString.Key: Any] = [
+    private let mainTextAttributes: [NSAttributedString.Key: Any] = [
         .font: UIFont.systemFont(ofSize: 20, weight: .bold),
         .foregroundColor: UIColor.challengeCardLabel,
         .baselineOffset: 2
     ]
+    
+    private let lengthTextAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 15, weight: .bold),
+        .foregroundColor: UIColor.challengeCardLabel,
+        .baselineOffset: 2
+    ]
+    
+    private var currentTextLength: Int = 0 {
+        didSet {
+            textLengthIndicatorLabel.attributedText = NSAttributedString(
+                string: "\(currentTextLength)/30",
+                attributes: lengthTextAttributes
+            )
+        }
+    }
     
     private let titleLabel: UILabel = {
         $0.text = "오늘의 챌린지를\n작성해주세요"
@@ -50,7 +65,7 @@ final class AddViewController: UIViewController {
     private lazy var placeholderLabel: UILabel = {
         $0.attributedText = NSAttributedString(
             string: "오늘의 다짐, 목표, 습관,\n영어문장, 할일 혹은\n무엇이든 좋아요",
-            attributes: attributes
+            attributes: mainTextAttributes
         )
         $0.numberOfLines = 0
         $0.textAlignment = .center
@@ -61,7 +76,7 @@ final class AddViewController: UIViewController {
     private lazy var addChallengeTextView: UITextView = {
         $0.attributedText = NSAttributedString(
             string: " ",
-            attributes: attributes
+            attributes: mainTextAttributes
         )
         $0.backgroundColor = .clear
         $0.textAlignment = .center
@@ -76,6 +91,15 @@ final class AddViewController: UIViewController {
         $0.returnKeyType = .done
         return $0
     }(UITextView())
+    
+    private lazy var textLengthIndicatorLabel: UILabel = {
+        $0.attributedText = NSAttributedString(
+            string: "\(currentTextLength)/30",
+            attributes: lengthTextAttributes
+        )
+        $0.layer.opacity = 0.7
+        return $0
+    }(UILabel())
     
     // MARK: LifeCycle
     
@@ -118,7 +142,7 @@ private extension AddViewController {
         
         addChallengeTextView.attributedText = NSAttributedString(
             string: "",
-            attributes: attributes
+            attributes: mainTextAttributes
         )
         addChallengeTextView.delegate = self
         textViewDidChange(addChallengeTextView)
@@ -133,7 +157,8 @@ private extension AddViewController {
             addChallengeCard,
             placeholderLabel,
             addChallengeTextView,
-            doneButton
+            doneButton,
+            textLengthIndicatorLabel
         )
         
         titleLabel.snp.makeConstraints {
@@ -166,6 +191,10 @@ private extension AddViewController {
             $0.center.equalTo(addChallengeCard)
             $0.horizontalEdges.equalTo(addChallengeCard).inset(20.adjusted)
         }
+        
+        textLengthIndicatorLabel.snp.makeConstraints {
+            $0.trailing.bottom.equalTo(addChallengeCard).inset(20.adjusted)
+        }
     }
     
     func doneButtonDidTap() {
@@ -192,6 +221,8 @@ extension AddViewController: UITextViewDelegate {
         if textView.text.count > 30 {
             textView.text.removeLast()
         }
+        
+        currentTextLength = textView.text.count
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {

--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -188,6 +188,10 @@ extension AddViewController: UITextViewDelegate {
             textView.tintColor = .tintColor
             doneButton.isEnabled = true
         }
+        
+        if textView.text.count > 30 {
+            textView.text.removeLast()
+        }
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #50 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 글자 수를 30자로 제한
    - 30자인 이유: 락스크린 위젯에서 대략 30자 정도까지만 안잘리고 표시되기 때문에
- 현재 글자수를 보여주는 인디케이터 추가

<img src="https://user-images.githubusercontent.com/75792767/210047317-561f5162-d42e-4a6c-926d-6dacfe187256.gif" width="250">

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- ZESTY의 닉네임 입력 참고함

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
