### PR TITLE
[Feat] 챌린지 수정

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		50C1BE3C295C87B1009A57BA /* AddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C1BE3B295C87B1009A57BA /* AddViewModel.swift */; };
 		50DBEA0A2952E94400ED00FD /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50DBEA092952E94400ED00FD /* Colors.xcassets */; };
 		50DBEA0F2952EBC300ED00FD /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DBEA0E2952EBC300ED00FD /* UIColor+.swift */; };
+		50F0C078295EDBFD009D49B5 /* ModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0C077295EDBFD009D49B5 /* ModifyViewController.swift */; };
+		50F0C07A295EDDD6009D49B5 /* ModifiyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0C079295EDDD6009D49B5 /* ModifiyViewModel.swift */; };
 		A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D1294A0A5F0044E652 /* AppDelegate.swift */; };
 		A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D3294A0A5F0044E652 /* SceneDelegate.swift */; };
 		A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
@@ -138,6 +140,8 @@
 		50C1BE3B295C87B1009A57BA /* AddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddViewModel.swift; sourceTree = "<group>"; };
 		50DBEA092952E94400ED00FD /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		50DBEA0E2952EBC300ED00FD /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
+		50F0C077295EDBFD009D49B5 /* ModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyViewController.swift; sourceTree = "<group>"; };
+		50F0C079295EDDD6009D49B5 /* ModifiyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifiyViewModel.swift; sourceTree = "<group>"; };
 		A79120CE294A0A5F0044E652 /* HRHN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HRHN.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A79120D1294A0A5F0044E652 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A79120D3294A0A5F0044E652 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -383,6 +387,7 @@
 				505B95342959926A005F00C8 /* ReviewViewController.swift */,
 				A7ED3EF5295C284200342CC8 /* SettingViewController.swift */,
 				50A5FFEA295D765700710B5D /* AddViewController.swift */,
+				50F0C077295EDBFD009D49B5 /* ModifyViewController.swift */,
 			);
 			path = VC;
 			sourceTree = "<group>";
@@ -426,6 +431,7 @@
 				A7ED3EF9295C6E6E00342CC8 /* SettingViewModel.swift */,
 				50C1BE3B295C87B1009A57BA /* AddViewModel.swift */,
 				A7ED3F0C295E23A700342CC8 /* OnBoardingViewModel.swift */,
+				50F0C079295EDDD6009D49B5 /* ModifiyViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -637,6 +643,7 @@
 				A7ED3EF8295C2FEF00342CC8 /* SettingCell.swift in Sources */,
 				A791214D295228200044E652 /* CGFloat+.swift in Sources */,
 				A79121622954C2D60044E652 /* ChallengeMO+CoreDataClass.swift in Sources */,
+				50F0C07A295EDDD6009D49B5 /* ModifiyViewModel.swift in Sources */,
 				50A5FFFE295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */,
 				505B953829599976005F00C8 /* UIViewController+.swift in Sources */,
 				A79121792955FBCE0044E652 /* CustomColor.swift in Sources */,
@@ -662,6 +669,7 @@
 				50BD589E29580C3E009F9556 /* UIFullWidthButton.swift in Sources */,
 				A791218229560B580044E652 /* RecordHeaderView.swift in Sources */,
 				507089B4295AE9D600DD8D85 /* ReviewViewModel.swift in Sources */,
+				50F0C078295EDBFD009D49B5 /* ModifyViewController.swift in Sources */,
 				A7ED3F0D295E23A700342CC8 /* OnBoardingViewModel.swift in Sources */,
 				A79121802956066E0044E652 /* RecordViewModel.swift in Sources */,
 				A7912186295775C00044E652 /* TodayViewModel.swift in Sources */,

--- a/HRHN/View/VC/AddViewController.swift
+++ b/HRHN/View/VC/AddViewController.swift
@@ -91,6 +91,7 @@ final class AddViewController: UIViewController {
         $0.centerVertically()
         $0.tintColor = .clear
         $0.returnKeyType = .done
+        $0.enablesReturnKeyAutomatically = true
         return $0
     }(UITextView())
     
@@ -229,7 +230,9 @@ extension AddViewController: UITextViewDelegate {
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         if text == "\n" {
-            doneButtonDidTap()
+            if textView.text.count > 0 {
+                doneButtonDidTap()
+            }
             return false
         }
         return true

--- a/HRHN/View/VC/ModifyViewController.swift
+++ b/HRHN/View/VC/ModifyViewController.swift
@@ -93,6 +93,7 @@ final class ModifyViewController: UIViewController {
         $0.centerVertically()
         $0.tintColor = .clear
         $0.returnKeyType = .done
+        $0.enablesReturnKeyAutomatically = true
         $0.delegate = self
         return $0
     }(UITextView())
@@ -215,7 +216,9 @@ extension ModifyViewController: UITextViewDelegate {
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         if text == "\n" {
-            doneButtonDidTap()
+            if textView.text.count > 0 {
+                doneButtonDidTap()
+            }
             return false
         }
         return true

--- a/HRHN/View/VC/ModifyViewController.swift
+++ b/HRHN/View/VC/ModifyViewController.swift
@@ -1,0 +1,223 @@
+//
+//  ModifyViewController.swift
+//  HRHN
+//
+//  Created by 민채호 on 2022/12/30.
+//
+
+import Combine
+import UIKit
+
+final class ModifyViewController: UIViewController {
+    
+    // MARK: Properties
+    
+    private let viewModel: ModifyViewModel
+    
+    private let mainTextAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 20, weight: .bold),
+        .foregroundColor: UIColor.challengeCardLabel,
+        .baselineOffset: 2
+    ]
+    
+    private let lengthTextAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 15, weight: .bold),
+        .foregroundColor: UIColor.challengeCardLabel,
+        .baselineOffset: 2
+    ]
+    
+    private let maxTextLength = 50
+    
+    private lazy var currentTextLength: Int = viewModel.currentChallenge?.content.count ?? 0 {
+        didSet {
+            textLengthIndicatorLabel.attributedText = NSAttributedString(
+                string: "\(currentTextLength)/\(maxTextLength)",
+                attributes: lengthTextAttributes
+            )
+        }
+    }
+    
+    private let titleLabel: UILabel = {
+        $0.text = "오늘의 챌린지를\n수정하세요"
+        $0.font = .systemFont(ofSize: 25, weight: .bold)
+        $0.numberOfLines = 0
+        return $0
+    }(UILabel())
+    
+    private let modifyChallengeCardLayoutView: UIView = {
+        return $0
+    }(UIView())
+    
+    private let modifyChallengeCard: UIView = {
+        $0.backgroundColor = .challengeCardFill
+        $0.layer.cornerRadius = 16
+        $0.layer.masksToBounds = true
+        return $0
+    }(UIView())
+    
+    private lazy var doneButton: UIFullWidthButton = {
+        $0.title = "완료"
+        $0.isOnKeyboard = true
+        $0.isEnabled = false
+        $0.action = UIAction { _ in
+            self.doneButtonDidTap()
+        }
+        return $0
+    }(UIFullWidthButton())
+    
+    private lazy var placeholderLabel: UILabel = {
+        $0.attributedText = NSAttributedString(
+            string: "오늘의 다짐, 목표, 습관,\n영어문장, 할일 혹은\n무엇이든 좋아요",
+            attributes: mainTextAttributes
+        )
+        $0.numberOfLines = 0
+        $0.textAlignment = .center
+        $0.layer.opacity = 0.3
+        $0.isHidden = true
+        return $0
+    }(UILabel())
+    
+    private lazy var modifyChallengeTextView: UITextView = {
+        $0.attributedText = NSAttributedString(
+            string: viewModel.currentChallenge?.content ?? "",
+            attributes: mainTextAttributes
+        )
+        $0.backgroundColor = .clear
+        $0.textAlignment = .center
+        $0.autocapitalizationType = .sentences
+        $0.autocorrectionType = .no
+        $0.textContainerInset = .zero
+        $0.contentInset = .zero
+        $0.scrollIndicatorInsets = .zero
+        $0.isScrollEnabled = false
+        $0.centerVertically()
+        $0.tintColor = .clear
+        $0.returnKeyType = .done
+        $0.delegate = self
+        return $0
+    }(UITextView())
+    
+    private lazy var textLengthIndicatorLabel: UILabel = {
+        $0.attributedText = NSAttributedString(
+            string: "\(currentTextLength)/\(maxTextLength)",
+            attributes: lengthTextAttributes
+        )
+        $0.layer.opacity = 0.7
+        return $0
+    }(UILabel())
+    
+    // MARK: LifeCycle
+    
+    init(viewModel: ModifyViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setLayout()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        modifyChallengeTextView.becomeFirstResponder()
+    }
+}
+
+// MARK: UI Functions
+
+private extension ModifyViewController {
+    
+    func setUI() {
+        view.backgroundColor = .background
+        textViewDidChange(modifyChallengeTextView)
+        navigationController?.navigationBar.topItem?.title = ""
+    }
+    
+    func setLayout() {
+        view.addSubviews(
+            titleLabel,
+            modifyChallengeCardLayoutView,
+            modifyChallengeCard,
+            placeholderLabel,
+            modifyChallengeTextView,
+            doneButton,
+            textLengthIndicatorLabel
+        )
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+        }
+        
+        doneButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top)
+        }
+        
+        modifyChallengeCardLayoutView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom)
+            $0.bottom.equalTo(doneButton.snp.top)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        modifyChallengeCard.snp.makeConstraints {
+            $0.center.equalTo(modifyChallengeCardLayoutView)
+            $0.horizontalEdges.equalToSuperview().inset(35)
+            $0.height.equalTo(200.adjusted)
+        }
+        
+        placeholderLabel.snp.makeConstraints {
+            $0.center.equalTo(modifyChallengeCard)
+            $0.edges.equalTo(modifyChallengeCard).inset(20.adjusted)
+        }
+        
+        modifyChallengeTextView.snp.makeConstraints {
+            $0.center.equalTo(modifyChallengeCard)
+            $0.horizontalEdges.equalTo(modifyChallengeCard).inset(20.adjusted)
+        }
+        
+        textLengthIndicatorLabel.snp.makeConstraints {
+            $0.trailing.bottom.equalTo(modifyChallengeCard).inset(20.adjusted)
+        }
+    }
+    
+    func doneButtonDidTap() {
+        self.viewModel.updateChallenge(modifyChallengeTextView.text)
+        self.viewModel.updateWidget()
+        self.navigationController?.popToRootViewController(animated: true)
+    }
+}
+
+// MARK: UITextViewDelegate
+
+extension ModifyViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            placeholderLabel.isHidden = false
+            textView.tintColor = .clear
+            doneButton.isEnabled = false
+        } else {
+            placeholderLabel.isHidden = true
+            textView.tintColor = .tintColor
+            doneButton.isEnabled = true
+        }
+        
+        if textView.text.count > maxTextLength {
+            textView.text.removeLast()
+        }
+        
+        currentTextLength = textView.text.count
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            doneButtonDidTap()
+            return false
+        }
+        return true
+    }
+}

--- a/HRHN/View/VC/ModifyViewController.swift
+++ b/HRHN/View/VC/ModifyViewController.swift
@@ -5,7 +5,6 @@
 //  Created by 민채호 on 2022/12/30.
 //
 
-import Combine
 import UIKit
 
 final class ModifyViewController: UIViewController {

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -119,7 +119,7 @@ extension TodayViewController {
     }
     
     @objc private func cardDidTap(tapGestureRecognizer: UITapGestureRecognizer) {
-        if viewModel.isPreviousChallengeExist() {
+        if viewModel.isTodayChallengeExist() {
             let modifyVC = ModifyViewController(viewModel: ModifyViewModel())
             modifyVC.hidesBottomBarWhenPushed = true
             navigationController?.pushViewController(modifyVC, animated: true)

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -33,6 +33,9 @@ final class TodayViewController: UIViewController {
         $0.backgroundColor = .challengeCardFill
         $0.layer.cornerRadius = 16
         $0.layer.masksToBounds = true
+        $0.isUserInteractionEnabled = true
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(cardDidTap(tapGestureRecognizer:)))
+        $0.addGestureRecognizer(tapGesture)
         return $0
     }(UIView())
     
@@ -104,7 +107,6 @@ extension TodayViewController {
     }
     
     @objc func addButtonDidTap(_ sender: UIButton) {
-        // TODO: - GO TO ADD-CHALLENGE
         if viewModel.isPreviousChallengeExist() {
             let reviewVC = ReviewViewController(viewModel: ReviewViewModel())
             reviewVC.hidesBottomBarWhenPushed = true
@@ -113,6 +115,14 @@ extension TodayViewController {
             let addVC = AddViewController(viewModel: AddViewModel())
             addVC.hidesBottomBarWhenPushed = true
             navigationController?.pushViewController(addVC, animated: true)
+        }
+    }
+    
+    @objc private func cardDidTap(tapGestureRecognizer: UITapGestureRecognizer) {
+        if viewModel.isPreviousChallengeExist() {
+            let modifyVC = ModifyViewController(viewModel: ModifyViewModel())
+            modifyVC.hidesBottomBarWhenPushed = true
+            navigationController?.pushViewController(modifyVC, animated: true)
         }
     }
 }

--- a/HRHN/ViewModel/ModifiyViewModel.swift
+++ b/HRHN/ViewModel/ModifiyViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  ModifiyViewModel.swift
+//  HRHN
+//
+//  Created by 민채호 on 2022/12/30.
+//
+
+import Foundation
+import WidgetKit
+
+final class ModifyViewModel: ObservableObject {
+    
+    @Published var currentChallenge: Challenge?
+    
+    private let coreDataManager = CoreDataManager.shared
+    private let widgetCenter = WidgetCenter.shared
+    
+    init() {
+        fetchCurrentChallenge()
+    }
+    
+    func fetchCurrentChallenge() {
+        let challenges = coreDataManager.getChallengeOf(Date())
+        if challenges.count > 0 {
+            currentChallenge = challenges[0]
+        }
+    }
+    
+    func updateChallenge(_ content: String) {
+        guard let currentChallenge else { return }
+        let updatedChallenge = Challenge(
+            id: currentChallenge.id,
+            date: currentChallenge.date,
+            content: content,
+            emoji: currentChallenge.emoji
+        )
+        coreDataManager.updateChallenge(updatedChallenge)
+    }
+    
+    func updateWidget() {
+        widgetCenter.reloadAllTimelines()
+    }
+}

--- a/HRHN/ViewModel/TodayViewModel.swift
+++ b/HRHN/ViewModel/TodayViewModel.swift
@@ -42,5 +42,12 @@ final class TodayViewModel {
             }
         }
     }
-
+    
+    func isTodayChallengeExist() -> Bool {
+        if todayChallenge.value == nil {
+            return false
+        } else {
+            return true
+        }
+    }
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #55 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- ModifyViewController와 ModifyViewModel 추가
- TodayViewController에서 오늘의 챌린지가 있을 때 챌린지 카드를 탭하면 ModifyVC로 이동
- 추가, 수정 화면에서 아무것도 입력되어 있지 않을 때 키보드의 'done'키가 활성화되어 있고 누르면 엔터가 입력되면서 챌린지가 추가되는 버그 수정

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
<img width="250" src="https://user-images.githubusercontent.com/75792767/210055706-56da37a4-2c23-4a46-b49d-0075ca64b43e.gif">

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- ModifyVC == AddVC
- @oreocube 오늘 논의에 따라 급하게 수정 플로우를 추가했는데 참고해주세요. 일정이 빠듯하시면 다음 버전에 추가하셔도 됩니다!

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
