### PR TITLE
[Bug] 오늘의 챌린지에 어제의 챌린지가 뜨는 버그 (타임존문제)

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		50DBEA0F2952EBC300ED00FD /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DBEA0E2952EBC300ED00FD /* UIColor+.swift */; };
 		50F0C078295EDBFD009D49B5 /* ModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0C077295EDBFD009D49B5 /* ModifyViewController.swift */; };
 		50F0C07A295EDDD6009D49B5 /* ModifiyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0C079295EDDD6009D49B5 /* ModifiyViewModel.swift */; };
+		A77158AF295F40EB00D96A82 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121682954FB600044E652 /* Date+.swift */; };
 		A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D1294A0A5F0044E652 /* AppDelegate.swift */; };
 		A79120D4294A0A5F0044E652 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79120D3294A0A5F0044E652 /* SceneDelegate.swift */; };
 		A79120DC294A0A5F0044E652 /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
@@ -625,6 +626,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A77158AF295F40EB00D96A82 /* Date+.swift in Sources */,
 				50A5FFF8295D784A00710B5D /* LockscreenWidget.swift in Sources */,
 				50A50011295D908500710B5D /* ChallengeMO+CoreDataClass.swift in Sources */,
 				50A50012295D908800710B5D /* ChallengeMO+CoreDataProperties.swift in Sources */,

--- a/HRHN/Extension/Date+.swift
+++ b/HRHN/Extension/Date+.swift
@@ -21,4 +21,16 @@ extension Date {
         formatter.timeZone = TimeZone(identifier: TimeZone.current.identifier)!
         return formatter.string(from: self)
     }
+    
+    /**
+     # getLocalizedDate
+     - Note: Date를 시간대에 맞게 사용하기 위해 시간대 별 시차를 적용해주는 함수
+     - Returns: 로컬라이징된 날짜
+     */
+    public func getLocalizedDate() -> Date {
+        let timezone = TimeZone.autoupdatingCurrent
+        let secondsFromGMT = timezone.secondsFromGMT(for: self)
+        return self.addingTimeInterval(TimeInterval(secondsFromGMT))
+    }
+    
 }

--- a/HRHN/Info.plist
+++ b/HRHN/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/HRHN/Managers/CoreDataManager.swift
+++ b/HRHN/Managers/CoreDataManager.swift
@@ -45,12 +45,12 @@ class CoreDataManager {
     
     func insertChallenge(_ challenge: Challenge) {
         guard let entity = NSEntityDescription.entity(forEntityName: "Challenge", in: context) else { return }
-        
         let existing = getChallengeOf(challenge.date)
         if existing.isEmpty {
             let managedObject = NSManagedObject(entity: entity, insertInto: context)
             managedObject.setValue(challenge.id, forKey: "id")
-            managedObject.setValue(challenge.date, forKey: "date")
+            managedObject.setValue(challenge.date.getLocalizedDate()
+                                   , forKey: "date")
             managedObject.setValue(challenge.emoji.rawValue, forKey: "emoji")
             managedObject.setValue(challenge.content, forKey: "content")
             do {
@@ -112,7 +112,7 @@ class CoreDataManager {
         var challenges: [Challenge] = []
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
-            let resultsByDate = fetchResults.filter({ isSameDay(date1: date, date2: $0.date)})
+            let resultsByDate = fetchResults.filter({ isSameDay(date1: date.getLocalizedDate(), date2: $0.date)})
             for result in resultsByDate {
                 let challenge = Challenge(id: result.id,
                                           date: result.date,

--- a/HRHN/Managers/CoreDataManager.swift
+++ b/HRHN/Managers/CoreDataManager.swift
@@ -44,13 +44,13 @@ class CoreDataManager {
     }
     
     func insertChallenge(_ challenge: Challenge) {
+        let targetDate = challenge.date.getLocalizedDate()
         guard let entity = NSEntityDescription.entity(forEntityName: "Challenge", in: context) else { return }
-        let existing = getChallengeOf(challenge.date)
+        let existing = getChallengeOf(targetDate)
         if existing.isEmpty {
             let managedObject = NSManagedObject(entity: entity, insertInto: context)
             managedObject.setValue(challenge.id, forKey: "id")
-            managedObject.setValue(challenge.date.getLocalizedDate()
-                                   , forKey: "date")
+            managedObject.setValue(targetDate, forKey: "date")
             managedObject.setValue(challenge.emoji.rawValue, forKey: "emoji")
             managedObject.setValue(challenge.content, forKey: "content")
             do {
@@ -93,9 +93,10 @@ class CoreDataManager {
     }
     
     func updateChallenge(_ challenge: Challenge) {
+        let targetDate = challenge.date.getLocalizedDate()
         let fetchResults = fetchChallenges()
         for result in fetchResults {
-            if isSameDay(date1: result.date, date2: challenge.date) {
+            if isSameDay(date1: result.date, date2: targetDate) {
                 result.emoji = challenge.emoji.rawValue
                 result.content = challenge.content
             }
@@ -109,10 +110,11 @@ class CoreDataManager {
     
     
     func getChallengeOf(_ date: Date) -> [Challenge] {
+        let targetDate = date.getLocalizedDate()
         var challenges: [Challenge] = []
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
-            let resultsByDate = fetchResults.filter({ isSameDay(date1: date.getLocalizedDate(), date2: $0.date)})
+            let resultsByDate = fetchResults.filter({ isSameDay(date1: targetDate, date2: $0.date)})
             for result in resultsByDate {
                 let challenge = Challenge(id: result.id,
                                           date: result.date,
@@ -128,9 +130,10 @@ class CoreDataManager {
     }
     
     func deleteChallenge(_ date: Date) {
+        let targetDate = date.getLocalizedDate()
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
-            let challenge = fetchResults.filter({ isSameDay(date1: date, date2: $0.date) })[0]
+            let challenge = fetchResults.filter({ isSameDay(date1: targetDate, date2: $0.date) })[0]
             context.delete(challenge)
             do {
                 try context.save()


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- Closes #60 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->

### 문제상황
오늘의 챌린지에 어제의 챌린지가 뜨는 문제 발견
(한국이 9시간 차이나기 때문에 이 차이가 그동안 발생하지 않아서 당연히 날짜 넘어가도 되는 걸로 테스트했는데, 실제로 오후 3시이후에 등록하여 12시 넘을때 기다려보니 안되는 문제 발견!)

![스크린샷 2022-12-31 오전 12 59 29](https://user-images.githubusercontent.com/63157395/210089300-ce17c6ab-6429-4fef-85e8-0f4a477971e1.png)

### 원인

Date 객체는 시간대(timezone)나 calendar system에 영향을 받지 않는 기준시(GMT) 날짜를 나타내게 되어 
각 지역별로 맞는 타임존을 설정해주어야 해서 TimeZone 을 추가하면 해결됨!

### 해결 
- timezone 을 계산하여 값을 등록하고 가져올 수 있도록 변경하였습니다. 
- localized된 date로 변환하는 date extension추가 (타겟 - widget에도 적용)
![스크린샷 2022-12-31 오전 1 09 01](https://user-images.githubusercontent.com/63157395/210090212-c2be38e1-044a-43f7-904a-18687c3458de.png)


<img src="https://user-images.githubusercontent.com/63157395/210089380-704dbaed-fbbe-4d64-abef-6a6a59855be4.PNG" width="250">




## 리뷰포인트
- 시간대를 변경하여도 잘 적용이 되는지 확인 바랍니다

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- https://velog.io/@cskime/iOS-%EC%8B%9C%EA%B0%84%EB%8C%80Timezone%EC%9D%84-%EA%B3%A0%EB%A0%A4%ED%95%9C-%EB%82%A0%EC%A7%9C-%EB%8B%A4%EB%A3%A8%EA%B8%B0

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
