### PR TITLE
[Bug] 챌린지 타임존 버그

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		507089B0295ABC2B00DD8D85 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089AF295ABC2B00DD8D85 /* Color+.swift */; };
 		507089B2295ADE1A00DD8D85 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B1295ADE1A00DD8D85 /* View+.swift */; };
 		507089B4295AE9D600DD8D85 /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */; };
+		5080B2ED29601A2A005115AA /* DateComponents+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5080B2EC29601A2A005115AA /* DateComponents+.swift */; };
+		5080B2EE29601A3D005115AA /* DateComponents+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5080B2EC29601A2A005115AA /* DateComponents+.swift */; };
+		5080B2EF29601A41005115AA /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121682954FB600044E652 /* Date+.swift */; };
 		50A50001295D784B00710B5D /* LockscreenWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 50A5FFF0295D784A00710B5D /* LockscreenWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		50A5000F295D8FD100710B5D /* HRHN.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A79120DA294A0A5F0044E652 /* HRHN.xcdatamodeld */; };
 		50A50010295D903D00710B5D /* Challenge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7912114294B1AAB0044E652 /* Challenge.swift */; };
@@ -123,6 +126,7 @@
 		507089AF295ABC2B00DD8D85 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		507089B1295ADE1A00DD8D85 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
+		5080B2EC29601A2A005115AA /* DateComponents+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateComponents+.swift"; sourceTree = "<group>"; };
 		50A5000B295D8B8300710B5D /* HRHN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HRHN.entitlements; sourceTree = "<group>"; };
 		50A5000C295D8BAD00710B5D /* LockscreenWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LockscreenWidgetExtension.entitlements; sourceTree = "<group>"; };
 		50A50016295D951600710B5D /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
@@ -348,6 +352,7 @@
 				A791214C295228200044E652 /* CGFloat+.swift */,
 				A791214E295228530044E652 /* Double+.swift */,
 				A79121682954FB600044E652 /* Date+.swift */,
+				5080B2EC29601A2A005115AA /* DateComponents+.swift */,
 				505B953729599976005F00C8 /* UIViewController+.swift */,
 				507089B1295ADE1A00DD8D85 /* View+.swift */,
 				A7ED3EFB295C735100342CC8 /* UserDefaults+.swift */,
@@ -628,9 +633,11 @@
 				50A5FFF8295D784A00710B5D /* LockscreenWidget.swift in Sources */,
 				50A50011295D908500710B5D /* ChallengeMO+CoreDataClass.swift in Sources */,
 				50A50012295D908800710B5D /* ChallengeMO+CoreDataProperties.swift in Sources */,
+				5080B2EE29601A3D005115AA /* DateComponents+.swift in Sources */,
 				50A50018295D953200710B5D /* URL+.swift in Sources */,
 				50A5000F295D8FD100710B5D /* HRHN.xcdatamodeld in Sources */,
 				50A5FFFD295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */,
+				5080B2EF29601A41005115AA /* Date+.swift in Sources */,
 				50A50013295D91AC00710B5D /* CoreDataManager.swift in Sources */,
 				50A50010295D903D00710B5D /* Challenge.swift in Sources */,
 			);
@@ -643,6 +650,7 @@
 				A7ED3EF8295C2FEF00342CC8 /* SettingCell.swift in Sources */,
 				A791214D295228200044E652 /* CGFloat+.swift in Sources */,
 				A79121622954C2D60044E652 /* ChallengeMO+CoreDataClass.swift in Sources */,
+				5080B2ED29601A2A005115AA /* DateComponents+.swift in Sources */,
 				50F0C07A295EDDD6009D49B5 /* ModifiyViewModel.swift in Sources */,
 				50A5FFFE295D784B00710B5D /* LockscreenWidget.intentdefinition in Sources */,
 				505B953829599976005F00C8 /* UIViewController+.swift in Sources */,

--- a/HRHN/AppDelegate.swift
+++ b/HRHN/AppDelegate.swift
@@ -8,6 +8,7 @@
 import CoreData
 import UIKit
 import UserNotifications
+import WidgetKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -25,6 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        WidgetCenter.shared.reloadAllTimelines()
     }
 }
 

--- a/HRHN/Extension/Date+.swift
+++ b/HRHN/Extension/Date+.swift
@@ -21,4 +21,8 @@ extension Date {
         formatter.timeZone = TimeZone(identifier: TimeZone.current.identifier)!
         return formatter.string(from: self)
     }
+    
+    func currentTimeZoneDate() -> Date {
+        return Calendar.current.date(from: DateComponents.convertTime(Date())) ?? Date()
+    }
 }

--- a/HRHN/Extension/DateComponents+.swift
+++ b/HRHN/Extension/DateComponents+.swift
@@ -1,0 +1,20 @@
+//
+//  DateComponents+.swift
+//  HRHN
+//
+//  Created by 민채호 on 2022/12/31.
+//
+
+import Foundation
+
+extension DateComponents {
+    
+    static func convertTime(_ date: Date) -> Self {
+        return .init(
+            timeZone: .autoupdatingCurrent,
+            year: Calendar.current.component(.year, from: Date()),
+            month: Calendar.current.component(.month, from: Date()),
+            day: Calendar.current.component(.day, from: Date())
+        )
+    }
+}

--- a/HRHN/Managers/CoreDataManager.swift
+++ b/HRHN/Managers/CoreDataManager.swift
@@ -94,10 +94,9 @@ class CoreDataManager {
     }
     
     func updateChallenge(_ challenge: Challenge) {
-        let currentTimeZoneDate = challenge.date.currentTimeZoneDate()
         let fetchResults = fetchChallenges()
         for result in fetchResults {
-            if isSameDay(date1: result.date, date2: currentTimeZoneDate) {
+            if isSameDay(date1: result.date, date2: challenge.date) {
                 result.emoji = challenge.emoji.rawValue
                 result.content = challenge.content
             }

--- a/HRHN/Managers/CoreDataManager.swift
+++ b/HRHN/Managers/CoreDataManager.swift
@@ -44,13 +44,14 @@ class CoreDataManager {
     }
     
     func insertChallenge(_ challenge: Challenge) {
+        let currentTimeZoneDate = challenge.date.currentTimeZoneDate()
         guard let entity = NSEntityDescription.entity(forEntityName: "Challenge", in: context) else { return }
         
-        let existing = getChallengeOf(challenge.date)
+        let existing = getChallengeOf(currentTimeZoneDate)
         if existing.isEmpty {
             let managedObject = NSManagedObject(entity: entity, insertInto: context)
             managedObject.setValue(challenge.id, forKey: "id")
-            managedObject.setValue(challenge.date, forKey: "date")
+            managedObject.setValue(currentTimeZoneDate, forKey: "date")
             managedObject.setValue(challenge.emoji.rawValue, forKey: "emoji")
             managedObject.setValue(challenge.content, forKey: "content")
             do {
@@ -93,9 +94,10 @@ class CoreDataManager {
     }
     
     func updateChallenge(_ challenge: Challenge) {
+        let currentTimeZoneDate = challenge.date.currentTimeZoneDate()
         let fetchResults = fetchChallenges()
         for result in fetchResults {
-            if isSameDay(date1: result.date, date2: challenge.date) {
+            if isSameDay(date1: result.date, date2: currentTimeZoneDate) {
                 result.emoji = challenge.emoji.rawValue
                 result.content = challenge.content
             }
@@ -109,10 +111,11 @@ class CoreDataManager {
     
     
     func getChallengeOf(_ date: Date) -> [Challenge] {
+        let currentTimeZoneDate = date.currentTimeZoneDate()
         var challenges: [Challenge] = []
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
-            let resultsByDate = fetchResults.filter({ isSameDay(date1: date, date2: $0.date)})
+            let resultsByDate = fetchResults.filter({ isSameDay(date1: currentTimeZoneDate, date2: $0.date)})
             for result in resultsByDate {
                 let challenge = Challenge(id: result.id,
                                           date: result.date,
@@ -128,9 +131,10 @@ class CoreDataManager {
     }
     
     func deleteChallenge(_ date: Date) {
+        let currentTimeZoneDate = date.currentTimeZoneDate()
         let fetchResults = fetchChallenges()
         if fetchResults.count > 0 {
-            let challenge = fetchResults.filter({ isSameDay(date1: date, date2: $0.date) })[0]
+            let challenge = fetchResults.filter({ isSameDay(date1: currentTimeZoneDate, date2: $0.date) })[0]
             context.delete(challenge)
             do {
                 try context.save()

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -92,6 +92,7 @@ final class TodayViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        dateLabel.text = Date().formatted("YYYY.MM.dd")
         bind()
     }
     

--- a/LockscreenWidget/LockscreenWidget.swift
+++ b/LockscreenWidget/LockscreenWidget.swift
@@ -34,8 +34,8 @@ struct Provider: IntentTimelineProvider {
     func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
         var entries: [SimpleEntry] = []
 
-        let currentDate = Date()
-        let midnight = Calendar.current.startOfDay(for: currentDate)
+        let currentTimeZoneDate = Date().currentTimeZoneDate()
+        let midnight = Calendar.current.startOfDay(for: currentTimeZoneDate)
         let nextMidnight = Calendar.current.date(
             byAdding: .day,
             value: 1,
@@ -43,7 +43,7 @@ struct Provider: IntentTimelineProvider {
         )!
         
         let entry = SimpleEntry(
-            date: currentDate,
+            date: currentTimeZoneDate,
             configuration: configuration,
             challenge: getTodayChallenge()
         )


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #60 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 기기의 타임존에 따른 현재 날짜를 가져오는 Date, DateComponenets 익스텐션 제작
- 익스텐션 적용
    - CoreDataManager
    - LockscreenWidget
- 앱 종료시 위젯 업데이트하는 로직 추가
- 앱 종료하지 않으면 TodayViewController 날짜 라벨이 업데이트되지 않는 버그 수정

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|챌린지 업데이트|위젯 업데이트|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/75792767/210130220-7561176c-456f-402e-aac5-619965a14883.mov" width="250">|<img src="https://user-images.githubusercontent.com/75792767/210130221-f957747e-b161-4567-b995-7cf068b37c19.mov" width="250">|

- 위젯 업데이트는 살짝 느리지만 알아서 되는것 확인 가능

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 71b5ecb DateComponents에 있는 timeZone 파라미터의 .autoupdatingCurrent를 이용하여 기기의 타임존을 불러오는 방법을 사용했습니다.
- 040587b CoreDataManager의 메서드에서 Date를 변환해주어 다른 곳에서 매니저를 이용할 때는 Date()로 전달해도 되도록 만들었습니다. (@chaneeii 의 방법!)

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- [MC3-Team7-MoTe](https://github.com/DeveloperAcademy-POSTECH/MC3-Team7-MoTe)
    - DateComponents 익스텐션을 참고함

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [ ] Xcode Team none 으로 되어있는지 확인
