### PR TITLE
[Hotfix] 앱스토어 수출문서 누락 관련 info.plist 설정

### DIFF
--- a/HRHN/Info.plist
+++ b/HRHN/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- Closes #67


## 작업내용
해당 프로퍼티를 설정하지 않으면 해외 수출규정관련문서를 업로드해야합니다.
하지만 저희는 따로 보안프로토콜 관련해서 신경쓸 내용이 없어
- AppUsesNonExemptEncryption 을 NO 로 설정했습니다.

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->

## Reference
<!-- 참고한 자료를 작성해주세요 -->
- https://green1229.tistory.com/206

## Checklist
- [x] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] Xcode Team none 으로 되어있는지 확인
