### PR TITLE
[Feat] 바구니 버튼 추가

### DIFF
--- a/HRHN/Extension/CGFloat+.swift
+++ b/HRHN/Extension/CGFloat+.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension CGFloat {
-    var adjusted: CGFloat {
+    var horizontallyAdjusted: CGFloat {
         let ratio: CGFloat = UIScreen.main.bounds.width / 390
         return self * ratio
     }

--- a/HRHN/Extension/CGFloat+.swift
+++ b/HRHN/Extension/CGFloat+.swift
@@ -13,4 +13,9 @@ extension CGFloat {
         let ratio: CGFloat = UIScreen.main.bounds.width / 390
         return self * ratio
     }
+    
+    var verticallyAdjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 844
+        return self * ratio
+    }
 }

--- a/HRHN/Extension/Double+.swift
+++ b/HRHN/Extension/Double+.swift
@@ -12,5 +12,10 @@ extension Double {
         let ratio: CGFloat = UIScreen.main.bounds.width / 390
         return CGFloat(self) * ratio
     }
+    
+    var verticallyAdjusted: CGFloat {
+        let ratio: CGFloat = UIScreen.main.bounds.height / 844
+        return self * ratio
+    }
 }
 

--- a/HRHN/Extension/Double+.swift
+++ b/HRHN/Extension/Double+.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension Double {
-    var adjusted: CGFloat {
+    var horizontallyAdjusted: CGFloat {
         let ratio: CGFloat = UIScreen.main.bounds.width / 390
         return CGFloat(self) * ratio
     }

--- a/HRHN/Helper/I18N.swift
+++ b/HRHN/Helper/I18N.swift
@@ -52,6 +52,9 @@ struct I18N {
     
     /* 지난챌린지 */
     static let recordTitle = "record-title".localized()
+    
+    /* 챌린지 바구니 */
+    static let storageTitle = "storage-title".localized()
         
     /* 설정 */
     static let settingTitle = "setting-title".localized()

--- a/HRHN/Localization/en.lproj/Localizable.strings
+++ b/HRHN/Localization/en.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 /* 지난챌린지 */
 "record-title" = "Achivements";
 
+/* 챌린지 바구니 */
+"storage-title" = "Storage";
+
 /* 설정 */
 "setting-title" = "Settings";
 "setting-noti-1" = "Notification";

--- a/HRHN/Localization/ko.lproj/Localizable.strings
+++ b/HRHN/Localization/ko.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 /* 지난챌린지 */
 "record-title" = "지난 챌린지";
 
+/* 챌린지 바구니 */
+"storage-title" = "바구니";
+
 /* 설정 */
 "setting-title" = "설정";
 "setting-noti-1" = "알림";

--- a/HRHN/Managers/DeviceManager.swift
+++ b/HRHN/Managers/DeviceManager.swift
@@ -13,7 +13,7 @@ private enum DeviceGroup {
     var rawValue: [Device] {
         switch self {
         case .homeButtonDevice:
-            return [.iPhone8, .iPhone8Plus, .iPhoneSE2, .iPhoneSE3]
+            return [.iPhone8, .iPhone8Plus, .iPhoneSE2, .iPhoneSE3, .simulator(.iPhoneSE3)]
         }
     }
 }

--- a/HRHN/View/UI/SwiftUIView/ReviewView.swift
+++ b/HRHN/View/UI/SwiftUIView/ReviewView.swift
@@ -31,16 +31,16 @@ struct ReviewView: View {
             Spacer(minLength: 20)
             Text(viewModel.challenge.content)
                 .foregroundColor(.cellLabel)
-                .padding(20.adjusted)
+                .padding(20.horizontallyAdjusted)
                 .frame(maxWidth: .infinity)
-                .frame(minHeight: 100.adjusted)
+                .frame(minHeight: 100.horizontallyAdjusted)
                 .background {
                     RoundedRectangle(cornerRadius: 16)
                         .foregroundColor(.cellFill)
                 }
                 .padding(.horizontal, 15)
             Spacer(minLength: 20)
-            Grid(horizontalSpacing: 10.adjusted, verticalSpacing: 10.adjusted) {
+            Grid(horizontalSpacing: 10.horizontallyAdjusted, verticalSpacing: 10.horizontallyAdjusted) {
                 GridRow {
                     emojiButton(.red)
                     emojiButton(.yellow)
@@ -67,7 +67,7 @@ private extension ReviewView {
     func emojiImage(_ emoji: Emoji) -> some View {
         Image(emoji.rawValue)
             .resizable()
-            .frame(width: 100.adjusted, height: 100.adjusted)
+            .frame(width: 100.horizontallyAdjusted, height: 100.horizontallyAdjusted)
     }
     
     @ViewBuilder

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -13,6 +13,12 @@ final class EditChallengeViewController: UIViewController {
     
     private let viewModel: EditChallengeViewModel
     
+    private enum DynamicPoints {
+        static let verticalSpacing: CGFloat = DeviceManager.shared.isHomeButtonDevice() ? 10 : 20
+        static let padding: CGFloat = DeviceManager.shared.isHomeButtonDevice() ? 10 : 20
+        static let cardHeight: CGFloat = DeviceManager.shared.isHomeButtonDevice() ? 140 : 180
+    }
+    
     private let mainTextAttributes: [NSAttributedString.Key: Any] = [
         .font: UIFont.systemFont(ofSize: 20, weight: .bold),
         .foregroundColor: UIColor.cellLabel,
@@ -36,6 +42,8 @@ final class EditChallengeViewController: UIViewController {
         }
     }
     
+    // MARK: UI
+    
     private lazy var titleLabel: UILabel = {
         switch viewModel.mode {
         case .add:
@@ -50,12 +58,42 @@ final class EditChallengeViewController: UIViewController {
     
     private let challengeCardLayoutView = UIView()
     
+    private lazy var cardAndButtonStackView: UIStackView = {
+        $0.axis = .vertical
+        $0.alignment = .trailing
+        $0.spacing = DynamicPoints.verticalSpacing
+        return $0
+    }(UIStackView())
+    
     private let challengeCard: UIView = {
         $0.backgroundColor = .cellFill
         $0.layer.cornerRadius = 16
         $0.layer.masksToBounds = true
         return $0
     }(UIView())
+    
+    private lazy var storageButton: UIButton = { [weak self] in
+        var titleAttribute = AttributedString("바구니")
+        titleAttribute.font = .systemFont(ofSize: 16)
+        $0.configuration?.attributedTitle = titleAttribute
+        
+        let imageConfig = UIImage.SymbolConfiguration(font: UIFont.systemFont(ofSize: 13))
+        $0.setImage(UIImage(systemName: "archivebox", withConfiguration: imageConfig), for: .normal)
+        $0.configuration?.imagePadding = 4
+        
+        $0.configuration?.baseBackgroundColor = .cellFill
+        $0.configuration?.baseForegroundColor = .cellLabel
+        $0.configuration?.cornerStyle = .fixed
+        $0.configuration?.background.cornerRadius = 16
+        $0.configuration?.contentInsets = .init(top: 0, leading: 20, bottom: 0, trailing: 20)
+        
+        let action = UIAction { _ in
+            self?.bucketButtonDidTap()
+        }
+        $0.addAction(action, for: .touchUpInside)
+        
+        return $0
+    }(UIButton(configuration: .filled()))
     
     private lazy var doneButton: UIFullWidthButton = { [weak self] in
         $0.title = I18N.btnDone
@@ -170,7 +208,8 @@ private extension EditChallengeViewController {
         )
         
         titleLabel.snp.makeConstraints {
-            $0.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(20)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(DynamicPoints.verticalSpacing)
+            $0.horizontalEdges.equalToSuperview().inset(20)
         }
         
         doneButton.snp.makeConstraints {
@@ -179,15 +218,32 @@ private extension EditChallengeViewController {
         }
         
         challengeCardLayoutView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom)
-            $0.bottom.equalTo(doneButton.snp.top)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(DynamicPoints.verticalSpacing)
+            $0.bottom.equalTo(doneButton.snp.top).offset(-DynamicPoints.verticalSpacing)
             $0.horizontalEdges.equalToSuperview()
         }
         
-        challengeCard.snp.makeConstraints {
-            $0.center.equalTo(challengeCardLayoutView)
+        challengeCardLayoutView.addSubview(cardAndButtonStackView)
+        
+        cardAndButtonStackView.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(35)
-            $0.height.equalTo(200.adjusted)
+        }
+        
+        switch viewModel.mode {
+        case .add:
+            cardAndButtonStackView.addArrangedSubviews(
+                challengeCard,
+                storageButton
+            )
+        case .modify:
+            cardAndButtonStackView.addArrangedSubviews(challengeCard)
+        }
+        
+        challengeCard.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(DynamicPoints.cardHeight)
         }
         
         placeholderLabel.snp.makeConstraints {
@@ -197,11 +253,15 @@ private extension EditChallengeViewController {
         
         challengeTextView.snp.makeConstraints {
             $0.center.equalTo(challengeCard)
-            $0.horizontalEdges.equalTo(challengeCard).inset(20.adjusted)
+            $0.horizontalEdges.equalTo(challengeCard).inset(DynamicPoints.padding)
         }
         
         textLengthIndicatorLabel.snp.makeConstraints {
-            $0.trailing.bottom.equalTo(challengeCard).inset(20.adjusted)
+            $0.trailing.bottom.equalTo(challengeCard).inset(DynamicPoints.padding)
+        }
+        
+        storageButton.snp.makeConstraints {
+            $0.height.equalTo(50)
         }
     }
     
@@ -216,6 +276,10 @@ private extension EditChallengeViewController {
             self.viewModel.updateWidget()
             self.navigationController?.popToRootViewController(animated: true)
         }
+    }
+    
+    func bucketButtonDidTap() {
+        
     }
 }
 

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -88,7 +88,7 @@ final class EditChallengeViewController: UIViewController {
         $0.configuration?.contentInsets = .init(top: 0, leading: 20, bottom: 0, trailing: 20)
         
         let action = UIAction { _ in
-            self?.bucketButtonDidTap()
+            self?.storageButtonDidTap()
         }
         $0.addAction(action, for: .touchUpInside)
         
@@ -278,7 +278,7 @@ private extension EditChallengeViewController {
         }
     }
     
-    func bucketButtonDidTap() {
+    func storageButtonDidTap() {
         
     }
 }

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -13,22 +13,14 @@ final class EditChallengeViewController: UIViewController {
     
     private let viewModel: EditChallengeViewModel
     
-    private enum DynamicPoints {
-        static let verticalSpacing: CGFloat = DeviceManager.shared.isHomeButtonDevice() ? 10 : 20
-        static let padding: CGFloat = DeviceManager.shared.isHomeButtonDevice() ? 10 : 20
-        static let cardHeight: CGFloat = DeviceManager.shared.isHomeButtonDevice() ? 140 : 180
-    }
-    
     private let mainTextAttributes: [NSAttributedString.Key: Any] = [
         .font: UIFont.systemFont(ofSize: 20, weight: .bold),
         .foregroundColor: UIColor.cellLabel,
-        .baselineOffset: 2
     ]
     
     private let lengthTextAttributes: [NSAttributedString.Key: Any] = [
         .font: UIFont.systemFont(ofSize: 15, weight: .bold),
         .foregroundColor: UIColor.cellLabel,
-        .baselineOffset: 2
     ]
     
     private let maxTextLength = 50
@@ -58,10 +50,10 @@ final class EditChallengeViewController: UIViewController {
     
     private let challengeCardLayoutView = UIView()
     
-    private lazy var cardAndButtonStackView: UIStackView = {
+    private lazy var stackView: UIStackView = {
         $0.axis = .vertical
         $0.alignment = .trailing
-        $0.spacing = DynamicPoints.verticalSpacing
+        $0.distribution = .equalSpacing
         return $0
     }(UIStackView())
     
@@ -197,71 +189,72 @@ private extension EditChallengeViewController {
     }
     
     func setLayout() {
+        
         view.addSubviews(
-            titleLabel,
-            challengeCardLayoutView,
-            challengeCard,
-            placeholderLabel,
+            stackView
+        )
+        
+        stackView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top)
+        }
+        
+        switch viewModel.mode {
+        case .add:
+            stackView.addArrangedSubviews(
+                titleLabel,
+                challengeCard,
+                storageButton,
+                doneButton
+            )
+        case .modify:
+            stackView.addArrangedSubviews(
+                titleLabel,
+                challengeCard,
+                doneButton
+            )
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+        }
+        
+        challengeCard.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(35)
+            $0.height.equalTo(180.verticallyAdjusted)
+        }
+        
+        challengeCard.addSubviews(
             challengeTextView,
-            doneButton,
+            placeholderLabel,
             textLengthIndicatorLabel
         )
         
-        titleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(DynamicPoints.verticalSpacing)
-            $0.horizontalEdges.equalToSuperview().inset(20)
+        challengeTextView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20.verticallyAdjusted)
+        }
+        
+        placeholderLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20.verticallyAdjusted)
+        }
+        
+        textLengthIndicatorLabel.snp.makeConstraints {
+            $0.trailing.bottom.equalToSuperview().inset(20.verticallyAdjusted)
+        }
+        
+        if viewModel.mode == .add {
+            storageButton.snp.makeConstraints {
+                $0.height.equalTo(50)
+                $0.right.equalTo(challengeCard)
+            }
         }
         
         doneButton.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(view.keyboardLayoutGuide.snp.top)
-        }
-        
-        challengeCardLayoutView.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(DynamicPoints.verticalSpacing)
-            $0.bottom.equalTo(doneButton.snp.top).offset(-DynamicPoints.verticalSpacing)
-            $0.horizontalEdges.equalToSuperview()
-        }
-        
-        challengeCardLayoutView.addSubview(cardAndButtonStackView)
-        
-        cardAndButtonStackView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.horizontalEdges.equalToSuperview().inset(35)
-        }
-        
-        switch viewModel.mode {
-        case .add:
-            cardAndButtonStackView.addArrangedSubviews(
-                challengeCard,
-                storageButton
-            )
-        case .modify:
-            cardAndButtonStackView.addArrangedSubviews(challengeCard)
-        }
-        
-        challengeCard.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview()
-            $0.centerX.equalToSuperview()
-            $0.height.equalTo(DynamicPoints.cardHeight)
-        }
-        
-        placeholderLabel.snp.makeConstraints {
-            $0.center.equalTo(challengeCard)
-            $0.edges.equalTo(challengeCard).inset(20.adjusted)
-        }
-        
-        challengeTextView.snp.makeConstraints {
-            $0.center.equalTo(challengeCard)
-            $0.horizontalEdges.equalTo(challengeCard).inset(DynamicPoints.padding)
-        }
-        
-        textLengthIndicatorLabel.snp.makeConstraints {
-            $0.trailing.bottom.equalTo(challengeCard).inset(DynamicPoints.padding)
-        }
-        
-        storageButton.snp.makeConstraints {
-            $0.height.equalTo(50)
         }
     }
     

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -73,7 +73,7 @@ final class EditChallengeViewController: UIViewController {
     }(UIView())
     
     private lazy var storageButton: UIButton = { [weak self] in
-        var titleAttribute = AttributedString("바구니")
+        var titleAttribute = AttributedString(I18N.storageTitle)
         titleAttribute.font = .systemFont(ofSize: 16)
         $0.configuration?.attributedTitle = titleAttribute
         

--- a/HRHN/View/VC/OnBoarding/OBSecondViewController.swift
+++ b/HRHN/View/VC/OnBoarding/OBSecondViewController.swift
@@ -52,7 +52,7 @@ extension OBSecondViewController {
     private func setUI() {
         view.addSubviews(titleLabel, subTitleLabel, imageView)
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(80.constraintMultiplierTargetValue.adjusted)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(80.constraintMultiplierTargetValue.horizontallyAdjusted)
             $0.height.equalTo(80)
             $0.centerX.equalToSuperview()
         }
@@ -65,8 +65,8 @@ extension OBSecondViewController {
         imageView.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(70)
             $0.centerX.equalToSuperview()
-            $0.width.equalTo(270.adjusted)
-            $0.height.equalTo(390.adjusted)
+            $0.width.equalTo(270.horizontallyAdjusted)
+            $0.height.equalTo(390.horizontallyAdjusted)
         }
     }
 }

--- a/HRHN/View/VC/OnBoarding/OBThirdViewController.swift
+++ b/HRHN/View/VC/OnBoarding/OBThirdViewController.swift
@@ -83,7 +83,7 @@ extension OBThirdViewController {
     private func setUI() {
         view.addSubviews(titleLabel, subTitleLabel, timeField, disableLabel, descLabel)
         titleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).inset(80.constraintMultiplierTargetValue.adjusted)
+            $0.top.equalTo(view.safeAreaLayoutGuide).inset(80.constraintMultiplierTargetValue.horizontallyAdjusted)
             $0.height.equalTo(80)
             $0.centerX.equalToSuperview()
         }
@@ -94,7 +94,7 @@ extension OBThirdViewController {
         }
         
         timeField.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(120.constraintMultiplierTargetValue.adjusted)
+            $0.top.equalTo(subTitleLabel.snp.bottom).offset(120.constraintMultiplierTargetValue.horizontallyAdjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(260)
             $0.height.equalTo(65)

--- a/HRHN/View/VC/TodayViewController.swift
+++ b/HRHN/View/VC/TodayViewController.swift
@@ -159,9 +159,9 @@ extension TodayViewController {
         
         view.addSubviews(cardView)
         cardView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(40.constraintMultiplierTargetValue.adjusted)
+            $0.leading.trailing.equalToSuperview().inset(40.constraintMultiplierTargetValue.horizontallyAdjusted)
             $0.centerY.equalToSuperview()
-            $0.height.equalTo(400.constraintMultiplierTargetValue.adjusted)
+            $0.height.equalTo(400.constraintMultiplierTargetValue.horizontallyAdjusted)
         }
         
     }
@@ -170,7 +170,7 @@ extension TodayViewController {
         emptyStackView.removeFromSuperview()
         cardView.addSubviews(challengeLabel)
         challengeLabel.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(20.constraintMultiplierTargetValue.adjusted)
+            $0.leading.trailing.equalToSuperview().inset(20.constraintMultiplierTargetValue.horizontallyAdjusted)
             $0.centerY.equalToSuperview()
         }
     }


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #88 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 바구니 버튼 추가
- EditChallengeVC의 레이아웃 코드 리팩토링
  - 전부 UIStackView 하나로 감쌈
- 기기 세로 길이에 따라 레이아웃을 다르게 주기 위해 verticallyAdjusted 익스텐션 코드를 추가하고, 기존의 adjusted를 horizontallyAdjusted로 이름 변경
- 로컬라이제이션 적용

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/75792767/217450017-145ded44-31ba-46b0-b52f-d23f81b9ac59.png" width="250">|<img width="250" src="https://user-images.githubusercontent.com/75792767/217450025-71371894-29f3-4205-bc55-8b328617672f.png">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 가로 비율은 아이폰14 390과 아이폰SE3 375로 했을 때 0.96밖에 안돼서 별 차이가 없고, 레이아웃이 깨지는 경우는 보통 높이가 부족해서여서 기기 높이 비율을 사용하는 verticallyAdjusted를 만들었습니다.
  - 앞으로 셀 높이 같은 곳에는 verticallyAdjusted를 적용하면 될 것 같습니다
- 타이틀과 챌린지텍스트뷰, 바구니버튼과 완료 버튼 사이사이 간격을 전부 동일하게 만들고 싶어서 UIStackView로 모두 감싼 후, distribution을 .equalSpacing으로 했습니다.
- 번역을 일단 임의로 했는데 첨삭 부탁드립니다

## Checklist
- [ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 컨벤션 지켰는지 확인
- [ ] final, private 제대로 넣었는지 확인
