### PR TITLE
[Feat] 챌린지 삭제, 텍스트 전체 삭제 기능 추가

### DIFF
--- a/HRHN/Helper/I18N.swift
+++ b/HRHN/Helper/I18N.swift
@@ -50,6 +50,13 @@ struct I18N {
     /* 챌린지 수정 */
     static let updateTitle = "update-title".localized()
     
+    /* 챌린지 삭제 */
+    static let deleteButtonTitle = "delete-button-title".localized()
+    static let deleteAlertTitle = "delete-alert-title".localized()
+    static let deleteAlertMessage = "delete-alert-message".localized()
+    static let deleteAlertConfirm = "delete-alert-confirm".localized()
+    static let deleteAlertCancel = "delete-alert-cancel".localized()
+    
     /* 지난챌린지 */
     static let recordTitle = "record-title".localized()
     

--- a/HRHN/Localization/en.lproj/Localizable.strings
+++ b/HRHN/Localization/en.lproj/Localizable.strings
@@ -48,6 +48,13 @@
 /* 챌린지 수정 */
 "update-title" = "Update your\ntoday’s challenge";
 
+/* 챌린지 삭제 */
+"delete-button-title" = "Delete";
+"delete-alert-title" = "Would you like to delete challenge?";
+"delete-alert-message" = "Today's challenge will be deleted.";
+"delete-alert-confirm" = "Delete";
+"delete-alert-cancel" = "Cancel";
+
 /* 지난챌린지 */
 "record-title" = "Achivements";
 

--- a/HRHN/Localization/ko.lproj/Localizable.strings
+++ b/HRHN/Localization/ko.lproj/Localizable.strings
@@ -48,6 +48,13 @@
 /* 챌린지 수정 */
 "update-title" = "오늘의 챌린지를\n수정하세요";
 
+/* 챌린지 삭제 */
+"delete-button-title" = "삭제";
+"delete-alert-title" = "챌린지를 삭제할까요?";
+"delete-alert-message" = "오늘의 챌린지가 삭제됩니다.";
+"delete-alert-confirm" = "삭제";
+"delete-alert-cancel" = "취소";
+
 /* 지난챌린지 */
 "record-title" = "지난 챌린지";
 

--- a/HRHN/View/UI/Component/UIFullWidthButton.swift
+++ b/HRHN/View/UI/Component/UIFullWidthButton.swift
@@ -42,15 +42,15 @@ final class UIFullWidthButton: UIButton {
 
 // MARK: Methods
 
-private extension UIFullWidthButton {
+extension UIFullWidthButton {
     
-    func setLabel() {
+    private func setLabel() {
         var titleAttribute = AttributedString(title)
         titleAttribute.font = .systemFont(ofSize: 14)
         configuration?.attributedTitle = titleAttribute
     }
     
-    func setCornerRadius() {
+    private func setCornerRadius() {
         if isOnKeyboard {
             configuration?.cornerStyle = .fixed
             configuration?.background.cornerRadius = 0
@@ -59,13 +59,13 @@ private extension UIFullWidthButton {
         }
     }
     
-    func setUI() {
+    private func setUI() {
         configuration?.baseBackgroundColor = .point
         configuration?.baseForegroundColor = .whiteLabel
         configuration?.cornerStyle = .capsule
     }
     
-    func setLayout() {
+    private func setLayout() {
         snp.makeConstraints {
             $0.height.equalTo(50)
         }

--- a/HRHN/View/UI/SwiftUIView/ReviewView.swift
+++ b/HRHN/View/UI/SwiftUIView/ReviewView.swift
@@ -61,17 +61,17 @@ struct ReviewView: View {
 
 // MARK: ViewBuilder
 
-private extension ReviewView {
+extension ReviewView {
     
     @ViewBuilder
-    func emojiImage(_ emoji: Emoji) -> some View {
+    private func emojiImage(_ emoji: Emoji) -> some View {
         Image(emoji.rawValue)
             .resizable()
             .frame(width: 100.horizontallyAdjusted, height: 100.horizontallyAdjusted)
     }
     
     @ViewBuilder
-    func emojiButton(_ emoji: Emoji) -> some View {
+    private func emojiButton(_ emoji: Emoji) -> some View {
         Button {
             viewModel.selectedEmoji = emoji
             viewModel.updateChallenge()

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -217,9 +217,9 @@ final class EditChallengeViewController: UIViewController {
 
 // MARK: UI Functions
 
-private extension EditChallengeViewController {
+extension EditChallengeViewController {
     
-    func setUI() {
+    private func setUI() {
         view.backgroundColor = .background
         navigationController?.navigationBar.topItem?.title = ""
         
@@ -237,7 +237,7 @@ private extension EditChallengeViewController {
         textViewDidChange(challengeTextView)
     }
     
-    func setLayout() {
+    private func setLayout() {
         
         view.addSubviews(
             stackView
@@ -337,18 +337,18 @@ extension EditChallengeViewController: UITextViewDelegate {
 
 // MARK: Methods
  
-private extension EditChallengeViewController {
+extension EditChallengeViewController {
     
-    func storageButtonDidTap() {
+    private func storageButtonDidTap() {
         
     }
     
     @objc
-    func deleteChallengeBarButtonDidTap() {
+    private func deleteChallengeBarButtonDidTap() {
         self.present(deleteChallengeAlert, animated: true)
     }
     
-    func checkTextLength(textView: UITextView?) {
+    private func checkTextLength(textView: UITextView?) {
         guard let textView else { return }
         if textView.text.isEmpty {
             placeholderLabel.isHidden = false
@@ -365,14 +365,14 @@ private extension EditChallengeViewController {
         currentTextLength = textView.text.count
     }
     
-    func deleteOverFlowedTexts(textView: UITextView) {
+    private func deleteOverFlowedTexts(textView: UITextView) {
         if textView.text.count > maxTextLength {
             let overflowRange = textView.text.index(textView.text.startIndex, offsetBy: 50)...
             textView.text.removeSubrange(overflowRange)
         }
     }
     
-    func stopEditingAndSaveChallenge() {
+    private func stopEditingAndSaveChallenge() {
         switch viewModel.mode {
         case .add:
             self.viewModel.createChallenge(self.challengeTextView.text as String)

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -151,24 +151,24 @@ final class EditChallengeViewController: UIViewController {
         $0.tintColor = .systemRed
         return $0
     }(UIBarButtonItem(
-        title: "삭제",
+        title: I18N.deleteButtonTitle,
         style: .plain,
         target: self,
         action: #selector(deleteChallengeBarButtonDidTap)
     ))
     
     private lazy var deleteChallengeAlert: UIAlertController = { [weak self] in
-        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
+        let deleteAction = UIAlertAction(title: I18N.deleteAlertConfirm, style: .destructive) { _ in
             self?.viewModel.deleteChallenge()
             self?.navigationController?.popToRootViewController(animated: true)
         }
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let cancelAction = UIAlertAction(title: I18N.deleteAlertCancel, style: .cancel)
         $0.addAction(deleteAction)
         $0.addAction(cancelAction)
         return $0
     }(UIAlertController(
-        title: "챌린지를 삭제할까요?",
-        message: "오늘의 챌린지가 삭제됩니다.",
+        title: I18N.deleteAlertTitle,
+        message: I18N.deleteAlertMessage,
         preferredStyle: .alert
     ))
     

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -277,7 +277,8 @@ private extension EditChallengeViewController {
         challengeCard.addSubviews(
             challengeTextView,
             placeholderLabel,
-            textLengthIndicatorLabel
+            textLengthIndicatorLabel,
+            clearTextButton
         )
         
         challengeTextView.snp.makeConstraints {
@@ -294,18 +295,16 @@ private extension EditChallengeViewController {
             $0.trailing.bottom.equalToSuperview().inset(20.verticallyAdjusted)
         }
         
-        if viewModel.mode == .add {
-            storageButton.snp.makeConstraints {
-                $0.height.equalTo(50)
-                $0.right.equalTo(challengeCard)
-            }
         clearTextButton.snp.makeConstraints {
             $0.trailing.equalTo(textLengthIndicatorLabel.snp.leading).offset(-3)
             $0.centerY.equalTo(textLengthIndicatorLabel)
         }
         
-        storageButton.snp.makeConstraints {
-            $0.height.equalTo(50)
+        if viewModel.mode == .add {
+            storageButton.snp.makeConstraints {
+                $0.height.equalTo(50)
+                $0.right.equalTo(challengeCard)
+            }
         }
         
         doneButton.snp.makeConstraints {

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -172,6 +172,26 @@ final class EditChallengeViewController: UIViewController {
         preferredStyle: .alert
     ))
     
+    private lazy var clearTextButton: UIButton = { [weak self] in
+        let imageConfig = UIImage.SymbolConfiguration(font: UIFont.systemFont(ofSize: 12, weight: .bold))
+        $0.setImage(UIImage(systemName: "xmark.circle", withConfiguration: imageConfig), for: .normal)
+        
+        $0.tintColor = .cellLabel
+        $0.layer.opacity = 0.7
+        
+        $0.configuration?.contentInsets = .zero
+        
+        let action = UIAction { _ in
+            self?.challengeTextView.text.removeAll()
+        }
+        $0.addAction(action, for: .touchUpInside)
+        
+        if viewModel.currentChallenge == nil {
+            $0.isHidden = true
+        }
+        return $0
+    }(UIButton(configuration: .plain()))
+    
     // MARK: LifeCycle
     
     init(viewModel: EditChallengeViewModel) {
@@ -278,6 +298,13 @@ private extension EditChallengeViewController {
                 $0.height.equalTo(50)
                 $0.right.equalTo(challengeCard)
             }
+        clearTextButton.snp.makeConstraints {
+            $0.trailing.equalTo(textLengthIndicatorLabel.snp.leading).offset(-3)
+            $0.centerY.equalTo(textLengthIndicatorLabel)
+        }
+        
+        storageButton.snp.makeConstraints {
+            $0.height.equalTo(50)
         }
         
         doneButton.snp.makeConstraints {
@@ -317,10 +344,12 @@ extension EditChallengeViewController: UITextViewDelegate {
             placeholderLabel.isHidden = false
             textView.tintColor = .clear
             doneButton.isEnabled = false
+            clearTextButton.isHidden = true
         } else {
             placeholderLabel.isHidden = true
             textView.tintColor = .tintColor
             doneButton.isEnabled = true
+            clearTextButton.isHidden = false
         }
         
         if textView.text.count > maxTextLength {

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -147,6 +147,31 @@ final class EditChallengeViewController: UIViewController {
         return $0
     }(UILabel())
     
+    private lazy var deleteChallengeBarButton: UIBarButtonItem = {
+        $0.tintColor = .systemRed
+        return $0
+    }(UIBarButtonItem(
+        title: "삭제",
+        style: .plain,
+        target: self,
+        action: #selector(deleteChallengeBarButtonDidTap)
+    ))
+    
+    private lazy var deleteChallengeAlert: UIAlertController = { [weak self] in
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
+            self?.viewModel.deleteChallenge()
+            self?.navigationController?.popToRootViewController(animated: true)
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        $0.addAction(deleteAction)
+        $0.addAction(cancelAction)
+        return $0
+    }(UIAlertController(
+        title: "챌린지를 삭제할까요?",
+        message: "오늘의 챌린지가 삭제됩니다.",
+        preferredStyle: .alert
+    ))
+    
     // MARK: LifeCycle
     
     init(viewModel: EditChallengeViewModel) {
@@ -177,12 +202,15 @@ private extension EditChallengeViewController {
         view.backgroundColor = .background
         navigationController?.navigationBar.topItem?.title = ""
         
-        if viewModel.mode == .add {
+        switch viewModel.mode {
+        case .add:
             challengeTextView.attributedText = NSAttributedString(
                 string: "",
                 attributes: mainTextAttributes
             )
             challengeTextView.delegate = self
+        case .modify:
+            navigationItem.rightBarButtonItem = deleteChallengeBarButton
         }
         
         textViewDidChange(challengeTextView)
@@ -273,6 +301,11 @@ private extension EditChallengeViewController {
     
     func storageButtonDidTap() {
         
+    }
+    
+    @objc
+    func deleteChallengeBarButtonDidTap() {
+        present(deleteChallengeAlert, animated: true)
     }
 }
 

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -92,7 +92,7 @@ final class EditChallengeViewController: UIViewController {
         $0.isOnKeyboard = true
         $0.isEnabled = false
         $0.action = UIAction { _ in
-            self?.stopChallengeEditing()
+            self?.stopEditingAndSaveChallenge()
         }
         return $0
     }(UIFullWidthButton())
@@ -323,8 +323,16 @@ extension EditChallengeViewController: UITextViewDelegate {
         checkTextLength(textView: textView)
     }
     
-    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        returnButtonDidTap(text: text, textView: textView)
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText input: String) -> Bool {
+        let returnButton = "\n"
+        let isTextExist = !textView.text.isEmpty
+        
+        if input == returnButton && isTextExist {
+            stopEditingAndSaveChallenge()
+            return false
+        } else {
+            return true
+        }
     }
 }
 
@@ -365,17 +373,7 @@ private extension EditChallengeViewController {
         }
     }
     
-    func returnButtonDidTap(text: String, textView: UITextView) -> Bool {
-        if text == "\n" {
-            if textView.text.count > 0 {
-                stopChallengeEditing()
-            }
-            return false
-        }
-        return true
-    }
-    
-    func stopChallengeEditing() {
+    func stopEditingAndSaveChallenge() {
         switch viewModel.mode {
         case .add:
             self.viewModel.createChallenge(self.challengeTextView.text as String)

--- a/HRHN/View/VC/EditChallengeViewController.swift
+++ b/HRHN/View/VC/EditChallengeViewController.swift
@@ -345,7 +345,7 @@ private extension EditChallengeViewController {
     
     @objc
     func deleteChallengeBarButtonDidTap() {
-        present(deleteChallengeAlert, animated: true)
+        self.present(deleteChallengeAlert, animated: true)
     }
     
     func checkTextLength(textView: UITextView?) {

--- a/HRHN/View/VC/ReviewViewController.swift
+++ b/HRHN/View/VC/ReviewViewController.swift
@@ -40,18 +40,18 @@ final class ReviewViewController: UIViewController {
 
 // MARK: Bindings
 
-private extension ReviewViewController {
+extension ReviewViewController {
     
-    func bind() {
+    private func bind() {
 
     }
 }
 
 // MARK: UI Functions
 
-private extension ReviewViewController {
+extension ReviewViewController {
     
-    func setUI() {
+    private func setUI() {
         view.backgroundColor = .background
         
         addChild(reviewViewHC)
@@ -63,7 +63,7 @@ private extension ReviewViewController {
         }
     }
     
-    func setNavigationBar() {
+    private func setNavigationBar() {
         navigationController?.navigationBar.topItem?.title = ""
     }
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #90 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 챌린지 수정 모드에서 오늘의 챌린지 삭제 기능 추가
- 챌린지 편집시 텍스트 전체 삭제하는 버튼 추가
- 뷰컨 메소드 가독성 정리
- 붙여넣기나, 스와이프 키보드, 제안 사용시 글자 수가 50자를 넘어갈 수 있었던 버그 수정
- 로컬라이제이션 적용

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|챌린지 삭제|텍스트 삭제|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/75792767/217451788-156b50eb-e7d7-450f-9582-7d0b48c02fb5.gif" width="250">|<img width="250" src="https://user-images.githubusercontent.com/75792767/217451878-eded720a-4350-49bf-93ba-fcbfdfbd7249.gif">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- 50자일 때 입력시 마지막 한 글자를 지우게 하는 방식으로 50자 제한을 뒀었는데, 이렇게 하니 한 번에 여러 글자를 입력하는 기능(붙여넣기 등) 사용시 50자를 넘어가게 되어 50자가 넘어갔을 때 50자 뒤로는 모두 지워버리도록 했습니다
- 번역 첨삭 부탁드립니다

## Checklist
- [ ] 브랜치를 가져와 작업한 경우 이전 브랜치에 PR을 보냈는지 확인
- [ ] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [ ] 필요없는 주석, 프린트문 제거했는지 확인
- [ ] 컨벤션 지켰는지 확인
- [ ] final, private 제대로 넣었는지 확인
