### PR TITLE
[Redesign] 내비게이션바

### DIFF
--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		500CA076299740260012779B /* CustomHeightTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500CA075299740260012779B /* CustomHeightTabBar.swift */; };
+		500CA071299697320012779B /* CustomNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500CA070299697320012779B /* CustomNavBar.swift */; };
 		505B95352959926A005F00C8 /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505B95342959926A005F00C8 /* ReviewViewController.swift */; };
 		505B953829599976005F00C8 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505B953729599976005F00C8 /* UIViewController+.swift */; };
 		505B953B29599A24005F00C8 /* ReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505B953A29599A24005F00C8 /* ReviewView.swift */; };
@@ -131,6 +132,7 @@
 
 /* Begin PBXFileReference section */
 		500CA075299740260012779B /* CustomHeightTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHeightTabBar.swift; sourceTree = "<group>"; };
+		500CA070299697320012779B /* CustomNavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavBar.swift; sourceTree = "<group>"; };
 		505B95342959926A005F00C8 /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
 		505B953729599976005F00C8 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		505B953A29599A24005F00C8 /* ReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewView.swift; sourceTree = "<group>"; };
@@ -248,6 +250,14 @@
 				500CA075299740260012779B /* CustomHeightTabBar.swift */,
 			);
 			path = TabBar;
+			sourceTree = "<group>";
+		};
+		500CA06F299697110012779B /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				500CA070299697320012779B /* CustomNavBar.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		505B9539295999EA005F00C8 /* SupportingViews */ = {
@@ -491,6 +501,7 @@
 				A7912187295775D50044E652 /* Helper */,
 				507305EF29965A8100A20CA1 /* Design */,
 				A791210F294B1A3A0044E652 /* Extension */,
+				500CA06F299697110012779B /* Protocol */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -795,6 +806,7 @@
 				A7ED3F07295E053600342CC8 /* OBFirstViewController.swift in Sources */,
 				A74C751A2975325B0046B1B1 /* String+.swift in Sources */,
 				A79121632954C2D60044E652 /* ChallengeMO+CoreDataProperties.swift in Sources */,
+				500CA071299697320012779B /* CustomNavBar.swift in Sources */,
 				A79121292950D2000044E652 /* RecordViewController.swift in Sources */,
 				A7ED3EFA295C6E6E00342CC8 /* SettingViewModel.swift in Sources */,
 				A7912115294B1AAB0044E652 /* Challenge.swift in Sources */,

--- a/HRHN.xcodeproj/project.pbxproj
+++ b/HRHN.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		507089B2295ADE1A00DD8D85 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B1295ADE1A00DD8D85 /* View+.swift */; };
 		507089B4295AE9D600DD8D85 /* ReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */; };
 		507305F229965AAB00A20CA1 /* TabIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507305F129965AAB00A20CA1 /* TabIcons.swift */; };
+		507305F42996652500A20CA1 /* UINavigationBar+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507305F32996652500A20CA1 /* UINavigationBar+.swift */; };
 		5080B2ED29601A2A005115AA /* DateComponents+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5080B2EC29601A2A005115AA /* DateComponents+.swift */; };
 		5080B2EE29601A3D005115AA /* DateComponents+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5080B2EC29601A2A005115AA /* DateComponents+.swift */; };
 		5080B2EF29601A41005115AA /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79121682954FB600044E652 /* Date+.swift */; };
@@ -137,6 +138,7 @@
 		507089B1295ADE1A00DD8D85 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		507089B3295AE9D600DD8D85 /* ReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewModel.swift; sourceTree = "<group>"; };
 		507305F129965AAB00A20CA1 /* TabIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIcons.swift; sourceTree = "<group>"; };
+		507305F32996652500A20CA1 /* UINavigationBar+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+.swift"; sourceTree = "<group>"; };
 		5080B2EC29601A2A005115AA /* DateComponents+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateComponents+.swift"; sourceTree = "<group>"; };
 		50A5000B295D8B8300710B5D /* HRHN.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HRHN.entitlements; sourceTree = "<group>"; };
 		50A5000C295D8BAD00710B5D /* LockscreenWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LockscreenWidgetExtension.entitlements; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 				50C1BE39295C7539009A57BA /* UITextView+.swift */,
 				50A50016295D951600710B5D /* URL+.swift */,
 				A74C75192975325B0046B1B1 /* String+.swift */,
+				507305F32996652500A20CA1 /* UINavigationBar+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -802,6 +805,7 @@
 				507089B0295ABC2B00DD8D85 /* Color+.swift in Sources */,
 				A791214B295227230044E652 /* DeviceManager.swift in Sources */,
 				A7ED3F0B295E192E00342CC8 /* OBThirdViewController.swift in Sources */,
+				507305F42996652500A20CA1 /* UINavigationBar+.swift in Sources */,
 				A79120D2294A0A5F0044E652 /* AppDelegate.swift in Sources */,
 				50BD58A029587240009F9556 /* FullWidthButton.swift in Sources */,
 				50BD589E29580C3E009F9556 /* UIFullWidthButton.swift in Sources */,

--- a/HRHN/Sources/Application/AppDelegate.swift
+++ b/HRHN/Sources/Application/AppDelegate.swift
@@ -16,6 +16,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UNUserNotificationCenter.current().delegate = self
         debugPrint("Documents Directory:", FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last ?? "Not Found!")
+        
+        UINavigationBar.setCustomNavBar()
+
         return true
     }
     

--- a/HRHN/Sources/UI/EditChallenge/EditChallengeViewController.swift
+++ b/HRHN/Sources/UI/EditChallenge/EditChallengeViewController.swift
@@ -147,16 +147,6 @@ final class EditChallengeViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private lazy var deleteChallengeBarButton: UIBarButtonItem = {
-        $0.tintColor = .systemRed
-        return $0
-    }(UIBarButtonItem(
-        title: I18N.deleteButtonTitle,
-        style: .plain,
-        target: self,
-        action: #selector(deleteChallengeBarButtonDidTap)
-    ))
-    
     private lazy var deleteChallengeAlert: UIAlertController = { [weak self] in
         let deleteAction = UIAlertAction(title: I18N.deleteAlertConfirm, style: .destructive) { _ in
             self?.viewModel.deleteChallenge()
@@ -217,11 +207,11 @@ final class EditChallengeViewController: UIViewController {
 
 // MARK: UI Functions
 
-extension EditChallengeViewController {
+extension EditChallengeViewController: CustomNavBar {
     
     private func setUI() {
         view.backgroundColor = .background
-        navigationController?.navigationBar.topItem?.title = ""
+        setNavigationBarBackButton()
         
         switch viewModel.mode {
         case .add:
@@ -231,7 +221,11 @@ extension EditChallengeViewController {
             )
             challengeTextView.delegate = self
         case .modify:
-            navigationItem.rightBarButtonItem = deleteChallengeBarButton
+            setNavigationBarRightLabelButton(
+                title: "삭제",
+                color: .systemRed,
+                action: #selector(rightBarButtonDidTap)
+            )
         }
         
         textViewDidChange(challengeTextView)
@@ -344,7 +338,7 @@ extension EditChallengeViewController {
     }
     
     @objc
-    private func deleteChallengeBarButtonDidTap() {
+    private func rightBarButtonDidTap() {
         self.present(deleteChallengeAlert, animated: true)
     }
     

--- a/HRHN/Sources/UI/Record/RecordViewController.swift
+++ b/HRHN/Sources/UI/Record/RecordViewController.swift
@@ -71,10 +71,13 @@ extension RecordViewController {
             $0.edges.equalToSuperview()
         }
     }
-    
+}
+
+extension RecordViewController: CustomNavBar {
     private func setNavigationBar() {
-        let rightBarButton: UIBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape"), style: .plain, target: self, action: #selector(settingsDidTap))
-        navigationItem.rightBarButtonItem = rightBarButton
+        setNavigationBarAppLogo()
+        setNavigationBarBackButton()
+        setNavigationBarRightIconButton(systemName: "gearshape.fill", action: #selector(settingsDidTap))
     }
 }
 

--- a/HRHN/Sources/UI/Review/ReviewViewController.swift
+++ b/HRHN/Sources/UI/Review/ReviewViewController.swift
@@ -62,9 +62,11 @@ extension ReviewViewController {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(120)
         }
     }
-    
+}
+
+extension ReviewViewController: CustomNavBar {
     private func setNavigationBar() {
-        navigationController?.navigationBar.topItem?.title = ""
+        setNavigationBarBackButton()
     }
 }
 

--- a/HRHN/Sources/UI/Setting/SettingViewController.swift
+++ b/HRHN/Sources/UI/Setting/SettingViewController.swift
@@ -82,12 +82,13 @@ extension SettingViewController {
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
     }
-    
-    private func setNavigationBar() {
-        navigationController?.navigationBar.topItem?.title = ""
-    }
 }
 
+extension SettingViewController: CustomNavBar {
+    private func setNavigationBar() {
+        setNavigationBarBackButton()
+    }
+}
 
 // MARK: - UITableViewDataSource
 

--- a/HRHN/Sources/UI/Today/TodayViewController.swift
+++ b/HRHN/Sources/UI/Today/TodayViewController.swift
@@ -187,9 +187,12 @@ extension TodayViewController {
             $0.height.equalTo(40)
         }
     }
-    
+}
+
+extension TodayViewController: CustomNavBar {
     private func setNavigationBar() {
-        let rightBarButton: UIBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape"), style: .plain, target: self, action: #selector(settingsDidTap))
-        navigationItem.rightBarButtonItem = rightBarButton
+        setNavigationBarAppLogo()
+        setNavigationBarBackButton()
+        setNavigationBarRightIconButton(systemName: "gearshape.fill", action: #selector(settingsDidTap))
     }
 }

--- a/HRHN/Sources/Utils/Extension/UINavigationBar+.swift
+++ b/HRHN/Sources/Utils/Extension/UINavigationBar+.swift
@@ -1,0 +1,21 @@
+//
+//  UINavigationBar+.swift
+//  HRHN
+//
+//  Created by 민채호 on 2023/02/10.
+//
+
+import UIKit
+
+extension UINavigationBar {
+    static func setCustomNavBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor(red: 244/255, green: 244/255, blue: 244/255, alpha: 0.3)
+        appearance.backgroundEffect = UIBlurEffect(style: .light)
+        appearance.shadowColor = .clear
+        appearance.shadowImage = UIImage()
+        Self.appearance().standardAppearance = appearance
+        Self.appearance().scrollEdgeAppearance = appearance
+    }
+}

--- a/HRHN/Sources/Utils/Protocol/CustomNavBar.swift
+++ b/HRHN/Sources/Utils/Protocol/CustomNavBar.swift
@@ -1,0 +1,50 @@
+//
+//  CustomNavBar.swift
+//  HRHN
+//
+//  Created by 민채호 on 2023/02/11.
+//
+
+import UIKit
+
+protocol CustomNavBar {
+    
+    func setAppLogo()
+    func setBackButton()
+    func setRightIconButton(systemName: String, action: Selector)
+}
+
+extension CustomNavBar where Self: UIViewController {
+    
+    func setAppLogo() {
+        let leftBarTitle: UILabel = {
+            $0.text = "1D1C"
+            $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
+            $0.textColor = UIColor(red: 60/255, green: 60/255, blue: 67/255, alpha: 0.4)
+            return $0
+        }(UILabel())
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftBarTitle)
+    }
+    
+    func setBackButton() {
+        let backButton: UIBarButtonItem = UIBarButtonItem(
+            title: "",
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        backButton.tintColor = UIColor(red: 60/255, green: 60/255, blue: 67/255, alpha: 0.4)
+        navigationItem.backBarButtonItem = backButton
+    }
+    
+    func setRightIconButton(systemName: String, action: Selector) {
+        let rightBarButton: UIBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: systemName),
+            style: .plain,
+            target: self,
+            action: action
+        )
+        rightBarButton.tintColor = UIColor(red: 60/255, green: 60/255, blue: 67/255, alpha: 0.4)
+        navigationItem.rightBarButtonItem = rightBarButton
+    }
+}

--- a/HRHN/Sources/Utils/Protocol/CustomNavBar.swift
+++ b/HRHN/Sources/Utils/Protocol/CustomNavBar.swift
@@ -9,14 +9,15 @@ import UIKit
 
 protocol CustomNavBar {
     
-    func setAppLogo()
-    func setBackButton()
-    func setRightIconButton(systemName: String, action: Selector)
+    func setNavigationBarAppLogo()
+    func setNavigationBarBackButton()
+    func setNavigationBarRightIconButton(systemName: String, action: Selector)
+    func setNavigationBarRightLabelButton(title: String, color: UIColor, action: Selector)
 }
 
 extension CustomNavBar where Self: UIViewController {
     
-    func setAppLogo() {
+    func setNavigationBarAppLogo() {
         let leftBarTitle: UILabel = {
             $0.text = "1D1C"
             $0.font = UIFont.systemFont(ofSize: 20, weight: .semibold)
@@ -26,7 +27,7 @@ extension CustomNavBar where Self: UIViewController {
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftBarTitle)
     }
     
-    func setBackButton() {
+    func setNavigationBarBackButton() {
         let backButton: UIBarButtonItem = UIBarButtonItem(
             title: "",
             style: .plain,
@@ -37,7 +38,7 @@ extension CustomNavBar where Self: UIViewController {
         navigationItem.backBarButtonItem = backButton
     }
     
-    func setRightIconButton(systemName: String, action: Selector) {
+    func setNavigationBarRightIconButton(systemName: String, action: Selector) {
         let rightBarButton: UIBarButtonItem = UIBarButtonItem(
             image: UIImage(systemName: systemName),
             style: .plain,
@@ -45,6 +46,17 @@ extension CustomNavBar where Self: UIViewController {
             action: action
         )
         rightBarButton.tintColor = UIColor(red: 60/255, green: 60/255, blue: 67/255, alpha: 0.4)
+        navigationItem.rightBarButtonItem = rightBarButton
+    }
+    
+    func setNavigationBarRightLabelButton(title: String, color: UIColor, action: Selector) {
+        let rightBarButton = UIBarButtonItem(
+            title: I18N.deleteButtonTitle,
+            style: .plain,
+            target: self,
+            action: action
+        )
+        rightBarButton.tintColor = color
         navigationItem.rightBarButtonItem = rightBarButton
     }
 }


### PR DESCRIPTION
## 개요
<!-- 이 PR에 대한 정보를 작성해주세요 / 관련이슈가 있는 경우 아래에 관련 이슈를 등록해주세요 -->
- #100 

## 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
- 내비게이션바 커스텀

<!-- (+스크린샷)이 있다면 적어주세요. 없으면 지워주세요-->
|작업 전|작업 후|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/75792767/218242966-c06b782f-5c9d-4b31-b8cd-eabb92c57ac5.png" width="250">|<img width="250" src="https://user-images.githubusercontent.com/75792767/218243359-1a2bba58-353b-4675-8291-d8be0c4ca31b.png">|

## 리뷰포인트
<!-- 리뷰가 필요한 포인트와 해당 되는 커밋을 링크로 걸어주세요. -->
- CustomNavBar protocol
  - navigationItem을 설정하도는 함수 선언
  - 뷰컨에서 채택 후 함수 바로 사용하면 됨
    ```swift
    extension TodayViewController: CustomNavBar {
      private func setNavigationBar() {
          setNavigationBarAppLogo()
          setNavigationBarBackButton()
          setNavigationBarRightIconButton(systemName: "gearshape.fill", action: #selector(settingsDidTap))
      }
    }
    ```
    - `setNavigationBarAppLogo()`
      - 내비게이션바 왼쪽에 1D1C 글씨 설정
    - `setNavigationBarBackButton()`
      - 내비게이션바 뒤로가기 버튼 설정
      - 뒤로가기가 나오는 이전 뷰컨에서 적용해줘야함
    - `setNavigationBarRightIconButton(systemName:action:)`
      - 내비게이션바 오른쪽 아이콘 버튼 설정
      - SF symbols 사용
    - `setNavigationBarRightLabelButton(title:color:action:)`
      - 내비게이션바 오른쪽 라벨 버튼 설정
